### PR TITLE
fix: NameError (undefined local variable or method `raw_data'

### DIFF
--- a/lib/test_sites/source_entry.rb
+++ b/lib/test_sites/source_entry.rb
@@ -88,13 +88,13 @@ module TestSites
     end
 
     def empty?
-      raw_data.empty?
+      @raw_data.empty?
     end
 
     private
 
     def raw_value(field)
-      normalize_whitespace(raw_data[field])
+      normalize_whitespace(@raw_data[field])
     end
 
     def normalize_whitespace(s)


### PR DESCRIPTION
Fixes this error when running in `irb`:
```ruby
irb(main):007:0> TestSites::Listings.new.listings.size
Traceback (most recent call last):
       11: from /Users/oblomov/.rbenv/versions/2.7.1/bin/irb:23:in `<main>'
       10: from /Users/oblomov/.rbenv/versions/2.7.1/bin/irb:23:in `load'
        9: from /Users/oblomov/.rbenv/versions/2.7.1/lib/ruby/gems/2.7.0/gems/irb-1.2.3/exe/irb:11:in `<top (required)>'
        8: from (irb):6
        7: from (irb):7:in `rescue in irb_binding'
        6: from /Users/oblomov/Documents/code/covid-storepoint/lib/test_sites/listings.rb:10:in `listings'
        5: from /Users/oblomov/Documents/code/covid-storepoint/lib/test_sites/source.rb:25:in `entries_with_geocoding'
        4: from /Users/oblomov/Documents/code/covid-storepoint/lib/test_sites/source.rb:35:in `entries_with_addresses'
        3: from /Users/oblomov/Documents/code/covid-storepoint/lib/test_sites/source.rb:57:in `entries'
        2: from /Users/oblomov/Documents/code/covid-storepoint/lib/test_sites/source.rb:57:in `reject'
        1: from /Users/oblomov/Documents/code/covid-storepoint/lib/test_sites/source_entry.rb:91:in `empty?'
NameError (undefined local variable or method `raw_data' for #<TestSites::SourceEntry:0x00007fd35c240ea0>)
Did you mean?  @raw_data
```
Not sure why the `attr_reader` didn't work from within the module—guess I've forgotten exactly how accessors scope! But, in any case, it fixes the bug.