### PR TITLE
Enable rubocop

### DIFF
--- a/.github/workflows/ruby.yml
+++ b/.github/workflows/ruby.yml
@@ -26,3 +26,4 @@ jobs:
       - name: Test
         run: |
           bundle exec rake test
+          bundle exec rubocop

--- a/lib/test_sites/cac.rb
+++ b/lib/test_sites/cac.rb
@@ -8,10 +8,12 @@ require 'jaro_winkler'
 module TestSites
   MILES_PER_METER = (1 / 1609.344)
 
+  # Overrides Hashie::Mash to disable warnings.
   class NoWarningMash < Hashie::Mash
     disable_warnings
   end
 
+  # Utility class for processing Coders Against Covid location data.
   class CAC
     SEPARATOR = ' - '
 
@@ -19,7 +21,8 @@ module TestSites
       CSV.open(DataFile.path('cac_comparison.csv'),
                'w',
                write_headers: true,
-               headers: ['Jaro-Winkler', 'Geo Distance', 'Ours', 'Closest CAC Match']) do |csv|
+               headers: ['Jaro-Winkler', 'Geo Distance', 'Ours',
+                         'Closest CAC Match']) do |csv|
         closest_matches.each do |match|
           csv << match
         end
@@ -44,12 +47,10 @@ module TestSites
       @cac_by_address ||=
         cac_data.each_with_object({}) do |entry_raw, acc|
           entry = NoWarningMash.new(entry_raw)
-          address = [
-            entry.location_address_street,
-            entry.location_address_locality,
-            entry.location_address_region,
-            entry.location_address_postal_code
-          ].join(SEPARATOR)
+          address = [entry.location_address_street,
+                     entry.location_address_locality,
+                     entry.location_address_region,
+                     entry.location_address_postal_code].join(SEPARATOR)
           acc[address] = entry
         end
     end
@@ -58,35 +59,37 @@ module TestSites
       @local_by_address ||=
         local_data.each_with_object({}) do |entry_raw, acc|
           entry = NoWarningMash.new(entry_raw.to_h)
-          address = [
-            entry.address,
-            entry.city,
-            entry.state,
-            entry.postcode
-          ].join(SEPARATOR)
+          address = [entry.address,
+                     entry.city,
+                     entry.state,
+                     entry.postcode].join(SEPARATOR)
           acc[address] = entry
         end
     end
 
+    # rubocop:disable Metrics/MethodLength, Style/MultilineBlockChain
     def closest_matches
-      closest_matches =
-        local_by_address.map do |local_addr, local_value|
-          cac_same_state = cac_for_state(local_value.state)
-          closest_add_match_cac = cac_same_state.max_by do |cac_addr, _|
-            JaroWinkler.distance local_addr, cac_addr
-          end
-          closet_cac_addr, closest_cac_value = closest_add_match_cac
-          if closet_cac_addr
-            dist = distance_miles(local_value, closest_cac_value)
-            [JaroWinkler.distance(local_addr, closet_cac_addr), dist, local_addr, closet_cac_addr]
-          else
-            ['-', '-', local_addr, '-']
-          end
-        end.sort_by { |e| e.first.is_a?(Float) ? -e.first : 999_999 }
+      local_by_address.map do |local_addr, local_value|
+        cac_same_state = cac_for_state(local_value.state)
+        closest_add_match_cac = cac_same_state.max_by do |cac_addr, _|
+          JaroWinkler.distance local_addr, cac_addr
+        end
+        closet_cac_addr, closest_cac_value = closest_add_match_cac
+        if closet_cac_addr
+          dist = distance_miles(local_value, closest_cac_value)
+          [JaroWinkler.distance(local_addr, closet_cac_addr), dist, local_addr,
+           closet_cac_addr]
+        else
+          ['-', '-', local_addr, '-']
+        end
+      end.sort_by { |e| e.first.is_a?(Float) ? -e.first : 999_999 }
     end
+    # rubocop:enable Metrics/MethodLength, Style/MultilineBlockChain
 
     def cac_for_state(state)
-      cac_by_address.filter { |_, cac_value| cac_value.location_address_region == state }.to_h
+      cac_by_address.filter do |_, cac_value|
+        cac_value.location_address_region == state
+      end.to_h
     end
 
     def distance_miles(local_value, cac_value)
@@ -94,11 +97,10 @@ module TestSites
         return 'unknown'
       end
 
-      distance =
-        Geodesics.distance(
-          local_value.lat.to_f, local_value.lng.to_f,
-          cac_value.location_latitude.to_f, cac_value.location_longitude.to_f
-        ) * MILES_PER_METER
+      distance = Geodesics.distance(
+        local_value.lat.to_f, local_value.lng.to_f,
+        cac_value.location_latitude.to_f, cac_value.location_longitude.to_f
+      ) * MILES_PER_METER
 
       distance.round(1)
     end

--- a/lib/test_sites/data_file.rb
+++ b/lib/test_sites/data_file.rb
@@ -1,6 +1,7 @@
 # frozen_string_literal: true
 
 module TestSites
+  # Wrapper for files in ./data.
   class DataFile
     def self.path(data_dir_relative_path)
       DataFile.new(data_dir_relative_path).to_s

--- a/lib/test_sites/geocoder_client.rb
+++ b/lib/test_sites/geocoder_client.rb
@@ -5,6 +5,7 @@ require 'geocoder'
 require 'redis'
 
 module TestSites
+  # Wrapper for geocoder API.
   class GeocoderClient
     GOOGLE_API_KEY_COVID = ENV['GOOGLE_API_KEY_COVID']
 
@@ -13,7 +14,7 @@ module TestSites
     end
 
     def gmaps
-      @gmaps ||= gmaps = GoogleMapsService::Client.new(key: GOOGLE_API_KEY_COVID)
+      @gmaps ||= GoogleMapsService::Client.new(key: GOOGLE_API_KEY_COVID)
     end
   end
 end

--- a/lib/test_sites/geocoder_result.rb
+++ b/lib/test_sites/geocoder_result.rb
@@ -3,6 +3,7 @@
 require 'json'
 
 module TestSites
+  # Wrapper for results from geocoder API.
   class GeocoderResult
     attr_reader :raw
 
@@ -12,14 +13,15 @@ module TestSites
 
     # test if two GeocoderResults are equal on the fields we care about
     def equal?(other)
-      %i[street_number route intersection premise subpremise city postcode state].each_with_object(true) do |type, acc|
-        acc &&= (send(type) == other.send(type))
+      %i[street_number route intersection premise subpremise city postcode
+         state].each_with_object({}) do |type, acc|
+        acc && (send(type) == other.send(type))
       end
     end
 
     def all_equal?(others)
-      others.each_with_object(true) do |other, acc|
-        acc &&= equal?(other)
+      others.each_with_object({}) do |other, acc|
+        acc && equal?(other)
       end
     end
 
@@ -58,7 +60,8 @@ module TestSites
     def component(type)
       value = address_components[type] || []
       if value.size > 1
-        raise "Multiple #{type} components for #{display_address}: #{value.join(', ')}"
+        raise "Multiple #{type} components for #{display_address}: "\
+              "#{value.join(', ')}"
       end
 
       value.first

--- a/lib/test_sites/geocoder_results.rb
+++ b/lib/test_sites/geocoder_results.rb
@@ -5,6 +5,7 @@ require 'hashie'
 require 'json'
 
 module TestSites
+  # Wrapper for results from geocoder API.
   class GeocoderResults
     GEOCODER_RESULTS_FILE = DataFile.path('geocoder_results.json')
 
@@ -21,12 +22,14 @@ module TestSites
 
     def dump_error_results
       puts "\n*** Error results: #{error_results.size}\n"
-      puts error_results.sort_by { |_k, v| v.size }.map { |(k, v)| "#{k} - (#{v.size})" }.join("\n")
+      puts error_results.sort_by { |_k, v| v.size }
+                        .map { |(k, v)| "#{k} - (#{v.size})" }.join("\n")
       true
     end
 
     def already_geocoded
-      @already_geocoded = raw_results.successes.keys + raw_results.exceptions.keys
+      @already_geocoded = raw_results.successes.keys +
+                          raw_results.exceptions.keys
     end
 
     # Filter out geocoder results
@@ -44,8 +47,8 @@ module TestSites
     def all_results
       @all_results ||=
         begin
-          raw_results[:successes].each_with_object({}) do |(address, raw_result), acc|
-            acc[address] = raw_result.map { |single_result| GeocoderResult.new(single_result) }
+          raw_results[:successes].each_with_object({}) do |(address, result), h|
+            h[address] = result.map { |a_result| GeocoderResult.new(a_result) }
           end
         end
     end
@@ -71,8 +74,8 @@ module TestSites
       Hashie::Mash.new(JSON.parse(File.read(path)))
     end
 
-    def save_json(f, obj)
-      File.open(f, 'w') do |f|
+    def save_json(file, obj)
+      File.open(file, 'w') do |f|
         f.write(JSON.pretty_generate(obj))
       end
     end

--- a/lib/test_sites/hour_parser.rb
+++ b/lib/test_sites/hour_parser.rb
@@ -7,8 +7,11 @@ require 'hashie'
 require 'json'
 
 module TestSites
+  # rubocop:disable Metrics/ClassLength
+  # Utility class for parsing hours from location data.
   class HourParser
-    DAYS_OF_THE_WEEK = %w[Monday Tuesday Wednesday Thursday Friday Saturday Sunday].freeze
+    DAYS_OF_THE_WEEK = %w[Monday Tuesday Wednesday Thursday Friday Saturday
+                          Sunday].freeze
 
     START_TIME_ONLY =
       '(opens?\\s+)?(?<start_time>\d{1,2}(:\d{1,2})?)' \
@@ -22,24 +25,31 @@ module TestSites
       '\s*(?<end_ampm>a\.?(m\.?)?|p\.?(m\.?)?)'
     TIME_RANGE_2 = TIME_RANGE.gsub('time>', 'time_2>').gsub('ampm>', 'ampm_2>')
     DAY_OF_WEEK = DAYS_OF_THE_WEEK.map { |d| "#{d}s?" } .join('|')
-    DAY_RANGE = "(?<start_day>#{DAY_OF_WEEK})\\s*(-|–|through|thru|to|&)\\s*(?<end_day>#{DAY_OF_WEEK})"
+    DAY_RANGE =
+      "(?<start_day>#{DAY_OF_WEEK})\\s*(-|–|through|thru|to|&)\\s*(?<end_day>"\
+      "#{DAY_OF_WEEK})"
     DAY_TIME_RANGE = "#{DAY_RANGE}(:|,)?\\s*#{TIME_RANGE}"
     TIME_DAY_RANGE = "#{TIME_RANGE},?\\s*#{DAY_RANGE}"
 
-    TWO_TIME_DAY_RANGE = "#{TIME_RANGE}\\s*(and|&)?\\s*#{TIME_RANGE_2}\\s*,?\\s*#{DAY_RANGE}"
-    DAY_TWO_TIME_RANGE = "#{DAY_RANGE},?\\s#{TIME_RANGE}\\s*(and|&)\\s*?#{TIME_RANGE_2}"
+    TWO_TIME_DAY_RANGE =
+      "#{TIME_RANGE}\\s*(and|&)?\\s*#{TIME_RANGE_2}\\s*,?\\s*#{DAY_RANGE}"
+    DAY_TWO_TIME_RANGE =
+      "#{DAY_RANGE},?\\s#{TIME_RANGE}\\s*(and|&)\\s*?#{TIME_RANGE_2}"
 
     DAILY = '(daily|every day|(seven|7) days\s*(a|per|\/)\s*week)\.?'
 
     EVERY_DAY_START_TIME = "#{START_TIME_ONLY},?\\s+#{DAILY}"
     EVERY_DAY_RANGE = "#{TIME_RANGE},?\\s+#{DAILY}"
     WEEKDAYS_RANGE = "#{TIME_RANGE},?\\s+(weekdays)"
-    CERTAIN_DAYS_TIME_DAY = "#{TIME_RANGE},?\\s*(?<days>((#{DAY_OF_WEEK})\\s*,?(\\s*and)?\\s*)+)"
-    CERTAIN_DAYS_DAY_TIME = "(?<days>((#{DAY_OF_WEEK})\\s*,?(\\s*and)?\\s*)+):?\\s*#{TIME_RANGE}"
+    CERTAIN_DAYS_TIME_DAY =
+      "#{TIME_RANGE},?\\s*(?<days>((#{DAY_OF_WEEK})\\s*,?(\\s*and)?\\s*)+)"
+    CERTAIN_DAYS_DAY_TIME =
+      "(?<days>((#{DAY_OF_WEEK})\\s*,?(\\s*and)?\\s*)+):?\\s*#{TIME_RANGE}"
 
     START_TIME_DAYS = "#{START_TIME_ONLY}(:|,)?\\s*#{DAY_RANGE}"
     DAYS_START_TIME = "#{DAY_RANGE}(:|,)?\\s*#{START_TIME_ONLY}"
 
+    # rubocop:disable Layout/LineLength
     BY_APPT_ONLY = /(?<phrase>(;|,|:)?\s*by appointment(\s*only)?\.?(\s*open daily)?(\.|:)?)/i.freeze
 
     HS_CHECK_WEBSITE = HourSpecifier.new(*Array.new(7,  'check website'))
@@ -49,9 +59,10 @@ module TestSites
     HS_BY_APPT_ONLY = HourSpecifier.new(by_appt_only: true)
 
     WHILE_SUPPLIES_LAST = /(?<phrase>\s*(as|while|until)(\s+that site's)?\s+(supplies|(test\s*)?kits|(daily\s*)?limits)\s+(last|run out|have been reached))/i.freeze
+    # rubocop:enable Layout/LineLength
 
+    # rubocop:disable Metrics/AbcSize, Metrics/CyclomaticComplexity, Metrics/MethodLength, Metrics/PerceivedComplexity
     def parse(raw)
-      orig = raw.clone
       while_supplies_last = WHILE_SUPPLIES_LAST =~ raw
       raw = raw.gsub($LAST_MATCH_INFO[:phrase], '') if while_supplies_last
 
@@ -61,10 +72,12 @@ module TestSites
       spec = range(raw, while_supplies_last, by_appt_only)
       unless spec
         if raw =~ /;/
-          specs = raw.split(';').map { |component| range(component, while_supplies_last, by_appt_only) }
+          specs = raw.split(';').map do |component|
+            range(component, while_supplies_last, by_appt_only)
+          end
           unless specs.compact.size < specs.size
-            spec = specs.each_with_object(HourSpecifier.new) do |spec, acc|
-              acc.merge(spec)
+            spec = specs.each_with_object(HourSpecifier.new) do |spec2, acc|
+              acc.merge(spec2)
             end
           end
         end
@@ -74,7 +87,9 @@ module TestSites
 
       spec
     end
+    # rubocop:enable Metrics/AbcSize, Metrics/CyclomaticComplexity, Metrics/MethodLength, Metrics/PerceivedComplexity
 
+    # rubocop:disable Metrics/AbcSize, Metrics/CyclomaticComplexity, Metrics/MethodLength, Metrics/PerceivedComplexity
     def range(raw, while_supplies_last, by_appt_only)
       s = raw&.downcase&.strip
       return nil if s.blank? && !by_appt_only
@@ -82,13 +97,17 @@ module TestSites
       s = s.gsub(/weekdays/i, 'Monday - Friday')
       s = s.gsub(/weekends/i, 'Saturday - Sunday')
 
-      if ['call', 'call to confirm', 'call to confirm for hours', 'call to confirm hours', 'check with facility'].include?(s)
+      if ['call', 'call to confirm', 'call to confirm for hours',
+          'call to confirm hours', 'check with facility'].include?(s)
         HS_CALL
       elsif ['check website'].include?(s)
         HS_CHECK_WEBSITE
-      elsif ['24/7', '24 hours', 'open 24 hours', 'open 24hrs', 'open 24 hrs'].include?(s)
+      elsif ['24/7', '24 hours', 'open 24 hours', 'open 24hrs', 'open 24 hrs']
+            .include?(s)
         HS_24_7
-      elsif ['not available', 'not specified at this time.', 'not yet available', 'currently not accepting appointments.', 'currently closed.', 'temporarily closed'].include?(s)
+      elsif ['not available', 'not specified at this time.',
+             'not yet available', 'currently not accepting appointments.',
+             'currently closed.', 'temporarily closed'].include?(s)
         HS_NOT_YET_AVAILABLE
       elsif by_appt_only && s.blank?
         every_day_specifier('by appointment only')
@@ -97,24 +116,31 @@ module TestSites
       elsif s =~ re(EVERY_DAY_RANGE)
         same_time_some_days($LAST_MATCH_INFO, DAYS_OF_THE_WEEK, by_appt_only)
       elsif s =~ re(WEEKDAYS_RANGE)
-        same_time_some_days($LAST_MATCH_INFO, DAYS_OF_THE_WEEK - %w[Saturday Sunday], by_appt_only)
+        same_time_some_days($LAST_MATCH_INFO,
+                            DAYS_OF_THE_WEEK - %w[Saturday Sunday],
+                            by_appt_only)
       elsif s =~ re(TIME_DAY_RANGE) || s =~ re(DAY_TIME_RANGE)
         day_time_specifier($LAST_MATCH_INFO, by_appt_only)
       elsif s =~ re(CERTAIN_DAYS_TIME_DAY) || s =~ re(CERTAIN_DAYS_DAY_TIME)
-        same_time_some_days($LAST_MATCH_INFO, normalize_day_list($LAST_MATCH_INFO), by_appt_only)
+        same_time_some_days($LAST_MATCH_INFO,
+                            normalize_day_list($LAST_MATCH_INFO),
+                            by_appt_only)
       elsif s =~ re(START_TIME_DAYS) || s =~ re(DAYS_START_TIME)
         start_time_only($LAST_MATCH_INFO, while_supplies_last, by_appt_only)
       elsif s =~ re(EVERY_DAY_START_TIME)
-        start_time_only_days($LAST_MATCH_INFO, DAYS_OF_THE_WEEK, while_supplies_last, by_appt_only)
+        start_time_only_days($LAST_MATCH_INFO, DAYS_OF_THE_WEEK,
+                             while_supplies_last, by_appt_only)
       elsif s =~ re(TWO_TIME_DAY_RANGE) || s =~ re(DAY_TWO_TIME_RANGE)
         day_two_time_specifier($LAST_MATCH_INFO)
       elsif s =~ re(DAY_RANGE)
         day_range_specifier($LAST_MATCH_INFO, while_supplies_last, by_appt_only)
       end
     end
+    # rubocop:enable Metrics/AbcSize, Metrics/CyclomaticComplexity, Metrics/MethodLength, Metrics/PerceivedComplexity
 
     def normalize_day_list(match)
-      match[:days].gsub(',', '').gsub(' and', ' ').gsub(/\s+/, ' ').split(' ').map(&:capitalize)
+      match[:days].gsub(',', '').gsub(' and', ' ').gsub(/\s+/, ' ').split(' ')
+                  .map(&:capitalize)
     end
 
     def day_time_specifier(match, by_appt_only)
@@ -142,9 +168,9 @@ module TestSites
     end
 
     def same_two_times_some_days(match, days)
-      time_span_1 = normalize_time_span(match)
-      time_span_2 = normalize_time_span_2(match)
-      time_span = "#{time_span_1} and #{time_span_2}"
+      time_span1 = normalize_time_span(match)
+      time_span2 = normalize_time_span_2(match)
+      time_span = "#{time_span1} and #{time_span2}"
       HourSpecifier.new.tap do |hs|
         days.each do |day|
           hs.send("#{normalize_day(day).downcase}=", time_span)
@@ -201,7 +227,7 @@ module TestSites
       time_span = handle_by_appt_only(time_span, by_appt_only)
       time_span = 'call for hours' if time_span.blank?
       create_spec(days, time_span)
-     end
+    end
 
     def day_index(day)
       DAYS_OF_THE_WEEK.find_index(normalize_day(day))
@@ -211,35 +237,37 @@ module TestSites
       day.capitalize.gsub(/s$/, '')
     end
 
-    def re(s)
-      Regexp.new("^#{s}$", Regexp::IGNORECASE)
+    def re(string)
+      Regexp.new("^#{string}$", Regexp::IGNORECASE)
     end
 
-    def every_day_specifier(s)
-      HourSpecifier.new(*Array.new(7, s))
+    def every_day_specifier(string)
+      HourSpecifier.new(*Array.new(7, string))
     end
 
-    def handle_by_appt_only(s, by_appt_only)
-      by_appt_only ? s + ' by appointment only' : s
+    def handle_by_appt_only(string, by_appt_only)
+      by_appt_only ? string + ' by appointment only' : string
     end
 
-    def handle_while_supplies_last(s, while_supplies_last)
-      while_supplies_last ? s + ' until supplies run out' : s
+    def handle_while_supplies_last(string, while_supplies_last)
+      while_supplies_last ? string + ' until supplies run out' : string
     end
 
+    # rubocop:disable Metrics/AbcSize
     def check_all
-      found = all_hours.filter do |d|
-        parse(d)
-      end.compact
-      if (all_hours - found).any?
+      found = all_hours.filter { |d| parse(d) }.compact
+      hours_left = all_hours - found
+      if hours_left.any?
         puts "Hour specifiers that couldn't be parsed:"
-        puts (all_hours - found).map { |spec| "* #{spec}" }.join("\n")
+        puts hours_left.map { |spec| "* #{spec}" }.join("\n")
       end
       puts "Hour specifiers: parsed #{found.size} out of #{all_hours.size}"
     end
+    # rubocop:enable Metrics/AbcSize
 
     def all_hours
       @all_hours ||= TestSites::Source.new.all_hours
     end
   end
+  # rubocop:enable Metrics/ClassLength
 end

--- a/lib/test_sites/hour_specifier.rb
+++ b/lib/test_sites/hour_specifier.rb
@@ -4,14 +4,19 @@ require 'active_support'
 require 'active_support/core_ext/object/blank'
 
 module TestSites
+  # Utility class for formatting hours.
   class HourSpecifier
-    attr_accessor :monday, :tuesday, :wednesday, :thursday, :friday, :saturday, :sunday
+    attr_accessor :monday, :tuesday, :wednesday, :thursday, :friday, :saturday,
+                  :sunday
     attr_accessor :while_supplies_last
     attr_accessor :by_appt_only
 
-    DAYS_OF_THE_WEEK = %w[monday tuesday wednesday thursday friday saturday sunday].freeze
+    DAYS_OF_THE_WEEK = %w[monday tuesday wednesday thursday friday saturday
+                          sunday].freeze
 
-    def initialize(monday = '', tuesday = '', wednesday = '', thursday = '', friday = '', saturday = '', sunday = '', by_appt_only: false)
+    # rubocop:disable Metrics/ParameterLists
+    def initialize(monday = '', tuesday = '', wednesday = '', thursday = '',
+                   friday = '', saturday = '', sunday = '', by_appt_only: false)
       @monday = monday
       @tuesday = tuesday
       @wednesday = wednesday
@@ -22,6 +27,7 @@ module TestSites
       @while_supplies_last = false
       @by_appt_only = by_appt_only
     end
+    # rubocop:enable Metrics/ParameterLists
 
     def merge(other_specifier)
       %i[monday tuesday wednesday thursday friday saturday sunday].each do |day|

--- a/lib/test_sites/listing.rb
+++ b/lib/test_sites/listing.rb
@@ -4,6 +4,7 @@ require 'hashie'
 require 'street_address'
 
 module TestSites
+  # Wrapper class for test site locations.
   class Listing
     attr_accessor :source_entry
     attr_reader :geocoder_result
@@ -43,7 +44,8 @@ module TestSites
     end
 
     delegate :street_number, :route, :intersection, :premise, :subpremise,
-             :city, :postcode, :state, :lat, :lng, :formatted_address, to: :geocoder_result
+             :city, :postcode, :state, :lat, :lng, :formatted_address,
+             to: :geocoder_result
 
     def country
       ''
@@ -104,16 +106,13 @@ module TestSites
     end
 
     def street_address_fallback
-      @address_fallback ||=
-        begin
-          if formatted_address
-            implicit_us_address = formatted_address.gsub(/, USA?/, '')
-            address = StreetAddress::US.parse(implicit_us_address)
-            if address&.number && address&.street && address&.street_type
-              "#{address.number} #{address.street} #{address.street_type}"
-            end
-          end || nil
+      if formatted_address
+        implicit_us_address = formatted_address.gsub(/, USA?/, '')
+        address = StreetAddress::US.parse(implicit_us_address)
+        if address&.number && address&.street && address&.street_type
+          "#{address.number} #{address.street} #{address.street_type}"
         end
+      end || nil
     end
 
     def hour_parser

--- a/lib/test_sites/listings.rb
+++ b/lib/test_sites/listings.rb
@@ -5,10 +5,12 @@ require 'hashie'
 require 'json'
 
 module TestSites
+  # Wrapper class for a test site location.
   class Listings
     def listings
       source.entries_with_geocoding.map do |source_entry|
-        Listing.new(source_entry, source.geocoder_result_for_source_entry(source_entry))
+        Listing.new(source_entry,
+                    source.geocoder_result_for_source_entry(source_entry))
       end
     end
 

--- a/lib/test_sites/source.rb
+++ b/lib/test_sites/source.rb
@@ -8,6 +8,7 @@ require 'json'
 require 'xsv'
 
 module TestSites
+  # Wrapper class for Evite locations file.
   class Source
     include Enumerable
     CURRENT_SOURCE_FILE = DataFile.path('current_source.csv')
@@ -51,23 +52,21 @@ module TestSites
     end
 
     def entries
-      @entries ||=
-        csv.map do |csv_row|
-          SourceEntry.new(csv_row)
-        end.reject(&:empty?)
+      @entries ||= csv.map do |csv_row|
+        SourceEntry.new(csv_row)
+      end.reject(&:empty?)
     end
 
     def csv
       source_file_ext = File.extname(source_file)
-      csv =
-        case source_file_ext
-        when '.csv'
-          csv_from_csv_file(source_file)
-        when '.xlsx'
-          csv_from_excel_file(source_file)
-        else
-          raise "Unknown file extension #{source_file_ext}"
-        end
+      csv = case source_file_ext
+            when '.csv'
+              csv_from_csv_file(source_file)
+            when '.xlsx'
+              csv_from_excel_file(source_file)
+            else
+              raise "Unknown file extension #{source_file_ext}"
+            end
       exclude_ignored ? csv.filter { |row| row['Ignore'].blank? } : csv
     end
 
@@ -92,9 +91,9 @@ module TestSites
     end
 
     def check_dup_primary_keys
-      if dup_primary_keys.any?
-        raise "Duplicate primary keys found: #{dup_primary_keys.join("\n")}"
-       end
+      return unless dup_primary_keys.any?
+
+      raise "Duplicate primary keys found: #{dup_primary_keys.join("\n")}"
     end
 
     def geocoder_results

--- a/lib/test_sites/source_diff.rb
+++ b/lib/test_sites/source_diff.rb
@@ -1,6 +1,7 @@
 # frozen_string_literal: true
 
 module TestSites
+  # Wrapper for capturing differences between location-data sources.
   class SourceDiff
     def initialize; end
 
@@ -17,6 +18,7 @@ module TestSites
     end
 
     DiffEntry = Struct.new(:source_entry, :possible_matches)
+    # rubocop:disable Style/MultilineBlockChain
     def available_only_in_first(first, second)
       first.reject do |first_entry|
         # Eliminate any entries from the first list for which
@@ -31,6 +33,7 @@ module TestSites
         DiffEntry.new(source_entry, possible_matches)
       end
     end
+    # rubocop:enable Style/MultilineBlockChain
 
     def source
       @source ||= Source.new(exclude_ignored: false)
@@ -40,11 +43,12 @@ module TestSites
       @latest_raw_source ||= Source.new(source_file: latest_raw_source_file)
     end
 
-    # Assume latest source file is the xlsx file in `data/raw_sources` with the largest
-    # number of worksheets
+    # Assume latest source file is the xlsx file in `data/raw_sources` with the
+    # largest number of worksheets
     def latest_raw_source_file
       @latest_raw_source_file ||=
-        Dir.glob(DataFile.path('raw_sources/*xlsx')).max_by { |f| Xsv::Workbook.open(f).sheets.size }
+        Dir.glob(DataFile.path('raw_sources/*xlsx'))
+           .max_by { |f| Xsv::Workbook.open(f).sheets.size }
     end
 
     def list
@@ -59,18 +63,21 @@ module TestSites
     def list_group(group)
       if group.any?
         puts group.size
-        puts group.map { |diff_entry| diff_entry.source_entry.primary_key }.join("\n")
+        puts group.map { |diff_entry| diff_entry.source_entry.primary_key }
+                  .join("\n")
       else
         puts 'none'
       end
     end
 
+    # rubocop:disable Metrics/AbcSize, Metrics/MethodLength
     def dump_additions
       CSV.open(DataFile.path('additions.csv'), 'wb') do |csv|
         csv << ['State', 'Name', 'Current Address', 'Possible Source Address']
         added.map do |added|
           source_entry = added.source_entry
-          source_fields = [source_entry.state, source_entry.name, source_entry.key_address]
+          source_fields = [source_entry.state, source_entry.name,
+                           source_entry.key_address]
           puts "** SOURCE: #{source_entry.primary_key}"
           if added.possible_matches.empty?
             csv << [*source_fields, '']
@@ -83,5 +90,6 @@ module TestSites
         end
       end
     end
+    # rubocop:enable Metrics/AbcSize, Metrics/MethodLength
   end
 end

--- a/lib/test_sites/source_entry.rb
+++ b/lib/test_sites/source_entry.rb
@@ -6,9 +6,11 @@ require 'csv'
 require 'hashie'
 require 'json'
 
+# Wrapper for testing-location sites.
 module TestSites
   attr_reader :raw_data
 
+  # Wrapper for a testing-location entry.
   class SourceEntry
     STATE_HEADER = 'State'
     NAME_HEADER = 'Testing Site Name'
@@ -76,7 +78,8 @@ module TestSites
     end
 
     def hash
-      %w[state name facility_type address zip phone hours url_source].map { |method_name| send(method_name) }.hash
+      %w[state name facility_type address zip phone hours url_source]
+        .map { |method_name| send(method_name) }.hash
     end
 
     def ==(other)
@@ -97,8 +100,8 @@ module TestSites
       normalize_whitespace(@raw_data[field])
     end
 
-    def normalize_whitespace(s)
-      s&.strip&.gsub(/\s+/, ' ')
+    def normalize_whitespace(string)
+      string&.strip&.gsub(/\s+/, ' ')
     end
 
     def key_field(header, field)

--- a/lib/test_sites/store_point.rb
+++ b/lib/test_sites/store_point.rb
@@ -3,25 +3,23 @@
 require 'csv'
 
 module TestSites
+  # Utility for formatting location data for Storepoint.
   class StorePoint
-    HEADERS = 'name,description,address,city,state,postcode,country,phone,website,email,monday,tuesday,wednesday,thursday,friday,saturday,sunday,tags,extra,lat,lng,hours'
+    HEADERS = %w[name description address city state postcode country phone
+                 website email monday tuesday wednesday thursday friday saturday
+                 sunday tags extra lat lng hours].freeze
     OUTPUT_FILE = DataFile.path('store_point.csv')
 
     attr_reader :debug
 
-    def update(debug: false)
-      @debug = debug
+    def update
       seen = Set.new
-      CSV.open(OUTPUT_FILE,
-               'w',
-               write_headers: true,
-               headers: HEADERS) do |csv|
+      CSV.open(OUTPUT_FILE, 'w', write_headers: true,
+                                 headers: HEADERS.join(',')) do |csv|
         listings.each do |listing|
           next if seen.member?(listing.raw_address)
 
           seen << listing.raw_address
-          puts "processing #{listing.raw_address}" if debug
-
           csv << headers.map { |header| listing.send(header) }
         end
       end
@@ -30,7 +28,7 @@ module TestSites
     end
 
     def headers
-      @headers ||= HEADERS.split(',')
+      @headers ||= HEADERS
     end
 
     def listings

--- a/test/rake_test.rb
+++ b/test/rake_test.rb
@@ -6,14 +6,16 @@ class RakeTest < TestSitesTestCase
   Rake.application.load_rakefile
 
   def test_compare_cac
-    unless ENV['GITHUB_RUN_ID'] # skip integration test if running on github
-      Rake.application.invoke_task 'compare_cac'
-      assert_true FileUtils.compare_file('data/cac_comparison.csv', 'test/fixtures/cac_comparison.csv')
-    end
+    return if ENV['GITHUB_RUN_ID'] # skip integration test if running on github
+
+    Rake.application.invoke_task 'compare_cac'
+    assert_true FileUtils.compare_file('data/cac_comparison.csv',
+                                       'test/fixtures/cac_comparison.csv')
   end
 
   def test_update_storepoint
     Rake.application.invoke_task 'update_storepoint'
-    assert_true FileUtils.compare_file('data/store_point.csv', 'test/fixtures/store_point.csv')
+    assert_true FileUtils.compare_file('data/store_point.csv',
+                                       'test/fixtures/store_point.csv')
   end
 end


### PR DESCRIPTION
 ## Goal
Enable rubocop to insure consistent style.

 ## Approach
1. Add `rubocop` to the GitHub config in `.github/workflows/ruby.yml`.
2. Fix the warnings.

Sorry for the giant PR, but there's no way around it. I *think* the tests cover everything so, if you agree, maybe focus on the class/module descriptions since I was just winging it?