### PR TITLE
Add check_cac_hours rake task

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -12,10 +12,18 @@ task :geocode do
   TestSites::Geocoder.new.process
 end
 
-desc 'Check with the hour listings in the source file all parse crrectly'
+desc 'Check that the hour listings in the source file all parse correctly'
 task :check_hours do
   load 'lib/test_sites.rb' unless defined?(TestSites)
   TestSites::HourParser.new.check_all
+end
+
+desc 'Check how many of the hour listings obtained from CAC parse correctly'
+task :check_cac_hours do
+  load 'lib/test_sites.rb' unless defined?(TestSites)
+  TestSites::HourParser.new.check_all(
+    hours_to_check: TestSites::CAC.new.all_hours
+  )
 end
 
 desc 'List duplicate addresses in source file'

--- a/lib/test_sites/hour_parser.rb
+++ b/lib/test_sites/hour_parser.rb
@@ -254,14 +254,15 @@ module TestSites
     end
 
     # rubocop:disable Metrics/AbcSize
-    def check_all
-      found = all_hours.filter { |d| parse(d) }.compact
-      hours_left = all_hours - found
+    def check_all(hours_to_check: all_hours)
+      unique_hours = hours_to_check.compact.sort.uniq
+      found = unique_hours.filter { |d| parse(d) }.compact
+      hours_left = unique_hours - found
       if hours_left.any?
         puts "Hour specifiers that couldn't be parsed:"
         puts hours_left.map { |spec| "* #{spec}" }.join("\n")
       end
-      puts "Hour specifiers: parsed #{found.size} out of #{all_hours.size}"
+      puts "Hour specifiers: parsed #{found.size} out of #{unique_hours.size}"
     end
     # rubocop:enable Metrics/AbcSize
 


### PR DESCRIPTION
Also, miscellaneous cleanup

Closes: #18 

 ## Goal
Determines how many of the "hours of operation" strings from CAC data our HourParser can parse.

 ## Approach
1. Added code to dump a report of strings from the CAC data that we can't parse as well as stats on the number we can parse out of the total.
2. Took the opportunity to do some refactoring & cleanup in related areas.

 