### PR TITLE
Refactor CAC

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -22,7 +22,7 @@ desc 'Check how many of the hour listings obtained from CAC parse correctly'
 task :check_cac_hours do
   load 'lib/test_sites.rb' unless defined?(TestSites)
   TestSites::HourParser.new.check_all(
-    hours_to_check: TestSites::CAC.new.all_hours
+    hours_to_check: TestSites::CAC.all_hours
   )
 end
 

--- a/lib/test_sites/cac.rb
+++ b/lib/test_sites/cac.rb
@@ -17,6 +17,14 @@ module TestSites
   class CAC
     SEPARATOR = ' - '
 
+    def self.all_hours
+      CAC.cac_data.map { |cac_entry| cac_entry['location_hours_of_operation'] }
+    end
+
+    def self.cac_data
+      Hashie::Array.new(JSON.parse(CAC.cac_raw_data))
+    end
+
     def self.cac_raw_data
       Faraday.get('https://api.findcovidtesting.com/api/v1/location').body
     end
@@ -33,19 +41,11 @@ module TestSites
       end
     end
 
-    def all_hours
-      cac_data.map { |cac_entry| cac_entry['location_hours_of_operation'] }
-    end
-
     private
-
-    def cac_data
-      @cac_data ||= Hashie::Array.new(JSON.parse(CAC.cac_raw_data))
-    end
 
     def cac_by_address
       @cac_by_address ||=
-        cac_data.each_with_object({}) do |entry_raw, acc|
+        CAC.cac_data.each_with_object({}) do |entry_raw, acc|
           entry = NoWarningMash.new(entry_raw)
           address = [entry.location_address_street,
                      entry.location_address_locality,

--- a/lib/test_sites/cac.rb
+++ b/lib/test_sites/cac.rb
@@ -39,10 +39,6 @@ module TestSites
 
     private
 
-    def local_data
-      @local_data ||= CSV.read('test/fixtures/store_point.csv', headers: true)
-    end
-
     def cac_data
       @cac_data ||= Hashie::Array.new(JSON.parse(CAC.cac_raw_data))
     end
@@ -61,7 +57,7 @@ module TestSites
 
     def local_by_address
       @local_by_address ||=
-        local_data.each_with_object({}) do |entry_raw, acc|
+        StorePoint.local_data.each_with_object({}) do |entry_raw, acc|
           entry = NoWarningMash.new(entry_raw.to_h)
           address = [entry.address,
                      entry.city,

--- a/lib/test_sites/cac.rb
+++ b/lib/test_sites/cac.rb
@@ -17,6 +17,10 @@ module TestSites
   class CAC
     SEPARATOR = ' - '
 
+    def self.cac_raw_data
+      Faraday.get('https://api.findcovidtesting.com/api/v1/location').body
+    end
+
     def dump_matches
       CSV.open(DataFile.path('cac_comparison.csv'),
                'w',
@@ -33,18 +37,14 @@ module TestSites
       cac_data.map { |cac_entry| cac_entry['location_hours_of_operation'] }
     end
 
-    def cac_data
-      @cac_data ||= Hashie::Array.new(JSON.parse(cac_raw_data))
-    end
-
     private
 
     def local_data
       @local_data ||= CSV.read('test/fixtures/store_point.csv', headers: true)
     end
 
-    def cac_raw_data
-      Faraday.get('https://api.findcovidtesting.com/api/v1/location').body
+    def cac_data
+      @cac_data ||= Hashie::Array.new(JSON.parse(CAC.cac_raw_data))
     end
 
     def cac_by_address

--- a/lib/test_sites/store_point.rb
+++ b/lib/test_sites/store_point.rb
@@ -12,6 +12,10 @@ module TestSites
 
     attr_reader :debug
 
+    def self.local_data
+      CSV.read('test/fixtures/store_point.csv', headers: true)
+    end
+
     def update
       seen = Set.new
       CSV.open(OUTPUT_FILE, 'w', write_headers: true,

--- a/test/rake_test.rb
+++ b/test/rake_test.rb
@@ -5,6 +5,12 @@ require 'test_helper'
 class RakeTest < TestSitesTestCase
   Rake.application.load_rakefile
 
+  def test_check_cac_hours
+    return if ENV['GITHUB_RUN_ID'] # skip integration test if running on github
+
+    Rake.application.invoke_task 'check_cac_hours'
+  end
+
   def test_compare_cac
     return if ENV['GITHUB_RUN_ID'] # skip integration test if running on github
 


### PR DESCRIPTION
Related: #9

 ## Goal
Refactor a few useful methods so they can be used statically. Distinguishing between class and instance methods will be important as we add persistence.

 ## Approach
1. Cover `rake check_cac_hours`.
2. Refactor `CAC#cac_data` as `StorePoint.cac_data` to decouple `CAC` from Storepoint data.
3. The rest are straight refactors from instance to class methods.

## Note
Extracted this from #9 to make the PRs more digestible.