### PR TITLE
Fix LOAD_PATH in test_helper

### DIFF
--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 # Include our application
-$LOAD_PATH.unshift '../lib'
+$LOAD_PATH.unshift File.expand_path('../lib', __dir__)
 load 'test_sites.rb' unless defined?(TestSites)
 
 require 'minitest/autorun'


### PR DESCRIPTION
Closes: #25 

 ## Goal

Tests are running from the command line and in the CI but the VS Code plugin I'm using, Ruby Test Explorer, is erroring out:

```
[2020-04-18 21:27:53.206] [ERROR] Error while finding Minitest test suite: Command failed: bundle exec rake -R $EXT_DIR vscode:minitest:list
rake aborted!
LoadError: cannot load such file -- test_sites.rb
```

The `LOAD_PATH` needs to be fixed..

 ## Approach
1. Supply correct value for `LOAD_PATH`
