### PR TITLE
Clean-up standard output

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -1,5 +1,13 @@
 # frozen_string_literal: true
 
+require 'logger'
+
+def self.logger
+  @logger = Logger.new(STDOUT)
+  @logger.level = ENV['LOG_LEVEL'].blank? ? Logger::ERROR : ENV['LOG_LEVEL']
+  @logger
+end
+
 task default: :test
 
 task :diff_sources do
@@ -30,7 +38,7 @@ desc 'List duplicate addresses in source file'
 task :list_dups do
   load 'lib/test_sites.rb' unless defined?(TestSites)
   dups = TestSites::Source.new.dup_addresses
-  puts "Duplicate addresses:\n" + (dups.empty? ? 'None' : dups.join("\n"))
+  logger.info dups.join("\n") unless dups.blank?
 end
 
 desc 'Export source file as Storepoint CSV'
@@ -39,7 +47,7 @@ task :update_storepoint do
   Rake::Task['check_hours'].execute
   Rake::Task['geocode'].execute
   TestSites::StorePoint.new.update
-  puts "*** Updated #{TestSites::StorePoint::OUTPUT_FILE}"
+  logger.info "*** Updated #{TestSites::StorePoint::OUTPUT_FILE}"
 end
 
 task :dump_additions do

--- a/lib/test_sites.rb
+++ b/lib/test_sites.rb
@@ -1,6 +1,7 @@
 # frozen_string_literal: true
 
 $LOAD_PATH.unshift(File.dirname(__FILE__))
+require 'logger'
 require 'test_sites/cac'
 require 'test_sites/data_file'
 require 'test_sites/geocoder_client'
@@ -16,6 +17,13 @@ require 'test_sites/geocoder_results'
 require 'test_sites/geocoder'
 require 'test_sites/source_diff'
 
+# Namespace for Spark Bio's test sites.
 module TestSites
-  VERSION = '0.1.0'
+  VERSION ||= '0.1.0'
+
+  def self.logger
+    @logger ||= Logger.new(STDOUT)
+    @logger.level = ENV['LOG_LEVEL'].blank? ? Logger::ERROR : ENV['LOG_LEVEL']
+    @logger
+  end
 end

--- a/lib/test_sites/geocoder.rb
+++ b/lib/test_sites/geocoder.rb
@@ -14,7 +14,7 @@ module TestSites
 
     # rubocop:disable Metrics/AbcSize, Metrics/MethodLength
     def geocode
-      puts "*** Geocoding #{source.size} listings"
+      TestSites.logger.debug "*** Geocoding #{source.size} listings"
 
       counters = Struct.new(:skipped, :successes, :exceptions).new(0, 0, 0)
       # rubocop:disable Style/MultilineBlockChain
@@ -25,19 +25,20 @@ module TestSites
         end
 
         begin
-          puts "geocoding #{entry.address}"
+          TestSites.logger.debug "geocoding #{entry.address}"
           acc[:successes][entry.address] = geocode_address(entry.address)
           counters.successes += 1
         rescue StandardError => e
-          puts "*** EXCEPTION for #{entry.address}"
+          TestSites.logger.debug "*** EXCEPTION for #{entry.address}"
           acc[:exceptions][entry.address] = { class: e.class.to_s,
                                               message: e.message }
           counters.excpetions += 1
         end
       end.tap do
-        puts '*** Gecoder Results'
-        puts "    Successes: #{counters.successes}, Exceptions: "\
-             "#{counters.exceptions}, Skipped: #{counters.skipped}"
+        TestSites.logger.debug '*** Gecoder Results'
+        TestSites.logger
+                 .debug "    Successes: #{counters.successes}, Exceptions: "\
+                        "#{counters.exceptions}, Skipped: #{counters.skipped}"
       end
       # rubocop:enable Style/MultilineBlockChain
     end

--- a/lib/test_sites/geocoder_results.rb
+++ b/lib/test_sites/geocoder_results.rb
@@ -21,9 +21,10 @@ module TestSites
     end
 
     def dump_error_results
-      puts "\n*** Error results: #{error_results.size}\n"
-      puts error_results.sort_by { |_k, v| v.size }
-                        .map { |(k, v)| "#{k} - (#{v.size})" }.join("\n")
+      TestSites.logger.debug "\n*** Error results: #{error_results.size}\n"
+      TestSites.logger.debug error_results.sort_by { |_k, v| v.size }
+                                          .map { |(k, v)| "#{k} - (#{v.size})" }
+                                          .join("\n")
       true
     end
 

--- a/lib/test_sites/hour_parser.rb
+++ b/lib/test_sites/hour_parser.rb
@@ -259,10 +259,12 @@ module TestSites
       found = unique_hours.filter { |d| parse(d) }.compact
       hours_left = unique_hours - found
       if hours_left.any?
-        puts "Hour specifiers that couldn't be parsed:"
-        puts hours_left.map { |spec| "* #{spec}" }.join("\n")
+        TestSites.logger.debug "Hour specifiers that couldn't be parsed:"
+        TestSites.logger.debug hours_left.map { |spec| "* #{spec}" }.join("\n")
       end
-      puts "Hour specifiers: parsed #{found.size} out of #{unique_hours.size}"
+      TestSites.logger
+               .debug
+      "Hour specifiers: parsed #{found.size} out of #{unique_hours.size}"
     end
     # rubocop:enable Metrics/AbcSize
 

--- a/lib/test_sites/source_diff.rb
+++ b/lib/test_sites/source_diff.rb
@@ -55,18 +55,19 @@ module TestSites
       print '*** Added: '
       list_group(added)
 
-      puts ''
+      TestSites.logger.debug ''
       print '*** Deleted: '
       list_group(deleted)
     end
 
     def list_group(group)
       if group.any?
-        puts group.size
-        puts group.map { |diff_entry| diff_entry.source_entry.primary_key }
-                  .join("\n")
+        TestSites.logger.debug group.size
+        TestSites.logger.debug group
+          .map { |diff_entry| diff_entry.source_entry.primary_key }
+          .join("\n")
       else
-        puts 'none'
+        TestSites.logger.debug 'none'
       end
     end
 
@@ -78,12 +79,12 @@ module TestSites
           source_entry = added.source_entry
           source_fields = [source_entry.state, source_entry.name,
                            source_entry.key_address]
-          puts "** SOURCE: #{source_entry.primary_key}"
+          TestSites.logger.debug "** SOURCE: #{source_entry.primary_key}"
           if added.possible_matches.empty?
             csv << [*source_fields, '']
           else
             added.possible_matches.each do |possible_match|
-              puts "...SOURCE: #{possible_match.primary_key}"
+              TestSites.logger.debug "...SOURCE: #{possible_match.primary_key}"
               csv << [*source_fields, possible_match.key_address]
             end
           end


### PR DESCRIPTION
 ## Goal
Replace debug output with logger.

 ## Approach
1. Add a static method `self.logger` that returns a `Logger` instance to `test_sites.rb` and `Rakefile`.
2. The default log level of `Logger::ERROR` can be overridden by `ENV['LOG_LEVEL']`.

## Notes
We'll have to refactor this to `Rails.logger` if/when we migrate to Rails.