### PR TITLE
Improve cac comparison

### DIFF
--- a/test/fixtures/cac_comparison.csv
+++ b/test/fixtures/cac_comparison.csv
@@ -1,946 +1,884 @@
-Jaro-Winkler,Geo Distance,Ours,Closest CAC Match
-1.0,0.0,"11111 S 84th St, Papillion, NE 68046","11111 S 84th St, Papillion, NE 68046"
-1.0,0.0,"5140 N California Ave, Chicago, IL 60625","5140 N California Ave, Chicago, IL 60625"
-1.0,0.1,"300 Med Tech Pkwy, Johnson City, TN 37604","300 Med Tech Pkwy, Johnson City, TN 37604"
-1.0,0.2,"2030 Temple Hill Rd, Erwin, TN 37650","2030 Temple Hill Rd, Erwin, TN 37650"
-1.0,0.0,"2000 Brookside Dr, Kingsport, TN 37660","2000 Brookside Dr, Kingsport, TN 37660"
-1.0,0.0,"356 9th St, Cimarron, NM 87714","356 9th St, Cimarron, NM 87714"
-1.0,0.0,"1400 E College Ave, McAlester, OK 74501","1400 E College Ave, McAlester, OK 74501"
-1.0,0.0,"232 S Woods Mill Rd, Chesterfield, MO 63017","232 S Woods Mill Rd, Chesterfield, MO 63017"
-1.0,0.1,"1099 S Beacon Blvd, Grand Haven, MI 49417","1099 S Beacon Blvd, Grand Haven, MI 49417"
-1.0,0.0,"8431 Fredericksburg Rd, San Antonio, TX 78229","8431 Fredericksburg Rd, San Antonio, TX 78229"
-1.0,0.0,"1000 Harrington St, Mt Clemens, MI 48043","1000 Harrington St, Mt Clemens, MI 48043"
-1.0,0.0,"364 S Front St, Memphis, TN 38103","364 S Front St, Memphis, TN 38103"
-1.0,0.0,"501 Marlins Way, Miami, FL 33125","501 Marlins Way, Miami, FL 33125"
-1.0,0.0,"2500 Victory Ave, Dallas, TX 75219","2500 Victory Ave, Dallas, TX 75219"
-1.0,0.0,"9191 S Polk St, Dallas, TX 75232","9191 S Polk St, Dallas, TX 75232"
-1.0,0.0,"3481 Austin Peay Hwy, Memphis, TN 38128","3481 Austin Peay Hwy, Memphis, TN 38128"
-1.0,0.0,"1111 S Irving Heights Dr, Irving, TX 75060","1111 S Irving Heights Dr, Irving, TX 75060"
-1.0,0.0,"2569 Douglass Ave, Memphis, TN 38114","2569 Douglass Ave, Memphis, TN 38114"
-1.0,0.0,"969 Frayser Blvd, Memphis, TN 38127","969 Frayser Blvd, Memphis, TN 38127"
-1.0,0.0,"10058 Long Point Rd, Houston, TX 77055","10058 Long Point Rd, Houston, TX 77055"
-1.0,0.0,"597 W 11th St, Panama City, FL 32401","597 W 11th St, Panama City, FL 32401"
-1.0,0.0,"11 Elliott Barker Ln, Angel Fire, NM 87710","11 Elliott Barker Ln, Angel Fire, NM 87710"
-1.0,0.1,"1000 Water St, Jacksonville, FL 32204","1000 Water St, Jacksonville, FL 32204"
-1.0,0.0,"2478 Nashville Hwy Suite A, Columbia, TN 38401","2478 Nashville Hwy Suite A, Columbia, TN 38401"
-1.0,0.0,"3200 W De Soto St, Pensacola, FL 32505","3200 W De Soto St, Pensacola, FL 32505"
-1.0,0.1,"2669 N Scenic Dr, Alamogordo, NM 88310","2669 N Scenic Dr, Alamogordo, NM 88310"
-1.0,0.0,"425 University Blvd, Round Rock, TX 78665","425 University Blvd, Round Rock, TX 78665"
-1.0,0.1,"266 Joule St, Alcoa, TN 37701","266 Joule St, Alcoa, TN 37701"
-1.0,0.1,"16901 Lakeside Hills Ct, Omaha, NE 68130","16901 Lakeside Hills Ct, Omaha, NE 68130"
-1.0,0.1,"342 Frey St, Ashland City, TN 37015","342 Frey St, Ashland City, TN 37015"
-1.0,0.1,"951 N Broad St, Tazewell, TN 37879","951 N Broad St, Tazewell, TN 37879"
-1.0,0.1,"851 Locust St, Rogersville, TN 37857","851 Locust St, Rogersville, TN 37857"
-1.0,0.1,"1420 Tusculum Blvd, Greeneville, TN 37745","1420 Tusculum Blvd, Greeneville, TN 37745"
-1.0,0.0,"2104 Dayton Ave, Nashville, TN 37210","2104 Dayton Ave, Nashville, TN 37210"
-1.0,0.1,"2500 Bellevue Medical Center Dr, Bellevue, NE 68123","2500 Bellevue Medical Center Dr, Bellevue, NE 68123"
-1.0,0.1,"1301 Grundman Blvd, Nebraska City, NE 68410","1301 Grundman Blvd, Nebraska City, NE 68410"
-1.0,1.7,"137 W North Ave, Northlake, IL 60164","137 W North Ave, Northlake, IL 60164"
-1.0,0.1,"893 Delaware St, Indianapolis, IN 46225","893 Delaware St, Indianapolis, IN 46225"
-1.0,0.0,"259 E Erie St, Chicago, IL 60611","259 E Erie St, Chicago, IL 60611"
-1.0,0.1,"2601 W Ave N, San Angelo, TX 76909","2601 W Ave N, San Angelo, TX 76909"
-1.0,0.0,"3855 West Chester Pike, Newtown Square, PA 19073","3855 West Chester Pike, Newtown Square, PA 19073"
-1.0,0.0,"1500 NY-9D, Wappingers Falls, NY 12590","1500 NY-9D, Wappingers Falls, NY 12590"
-1.0,0.1,"555 N Duke St, Lancaster, PA 17602","555 N Duke St, Lancaster, PA 17602"
-1.0,0.1,"850 Greenfield Rd, Lancaster, PA 17601","850 Greenfield Rd, Lancaster, PA 17601"
-1.0,0.0,"1212 Liggett Ave, Reading, PA 19611","1212 Liggett Ave, Reading, PA 19611"
-1.0,0.0,"315 Mocksville Ave, Salisbury, NC 28144","315 Mocksville Ave, Salisbury, NC 28144"
-1.0,0.0,"1200 Old York Rd, Abington, PA 19001","1200 Old York Rd, Abington, PA 19001"
-1.0,0.1,"46 Fairview Ave, Skowhegan, ME 04976","46 Fairview Ave, Skowhegan, ME 04976"
-1.0,0.1,"863 Nazareth Pike, Nazareth, PA 18064","863 Nazareth Pike, Nazareth, PA 18064"
-1.0,0.0,"35 Miles St, Damariscotta, ME 04543","35 Miles St, Damariscotta, ME 04543"
-1.0,0.1,"16700 Jog Rd, Delray Beach, FL 33446","16700 Jog Rd, Delray Beach, FL 33446"
-1.0,0.0,"200 Kennedy Memorial Dr, Waterville, ME 04901","200 Kennedy Memorial Dr, Waterville, ME 04901"
-1.0,0.0,"50 Union St, Ellsworth, ME 04605","50 Union St, Ellsworth, ME 04605"
-1.0,0.1,"111 Franklin health commons, Farmington, ME 04938","111 Franklin health commons, Farmington, ME 04938"
-1.0,0.1,"300 Main St, Lewiston, ME 04240","300 Main St, Lewiston, ME 04240"
-1.0,0.2,"840 Cherokee Trail, Copperhill, TN 37317","840 Cherokee Trail, Copperhill, TN 37317"
-1.0,1.9,"25500 Point Lookout Rd, Leonardtown, MD 20650","25500 Point Lookout Rd, Leonardtown, MD 20650"
-1.0,0.1,"1 Citizens Bank Way, Philadelphia, PA 19148","1 Citizens Bank Way, Philadelphia, PA 19148"
-1.0,0.0,"1 Jarrett White Rd, Medical Center, HI 96859","1 Jarrett White Rd, Medical Center, HI 96859"
-1.0,0.1,"1301 Punchbowl St, Honolulu, HI 96813","1301 Punchbowl St, Honolulu, HI 96813"
-1.0,4.5,"91-2141 Fort Weaver Rd, Ewa Beach, HI 96706","91-2141 Fort Weaver Rd, Ewa Beach, HI 96706"
-1.0,0.1,"3900 Broadway, Everett, WA 98201","3900 Broadway, Everett, WA 98201"
-1.0,6.9,"1429 N Quincy St, Arlington, VA 22207","1429 N Quincy St, Arlington, VA 22207"
-1.0,0.1,"1800 Orleans St, Baltimore, MD 21287","1800 Orleans St, Baltimore, MD 21287"
-1.0,0.0,"10680 Del Mar Pkwy, Aurora, CO 80010","10680 Del Mar Pkwy, Aurora, CO 80010"
-1.0,0.1,"16942 GA-67, Statesboro, GA 30458","16942 GA-67, Statesboro, GA 30458"
-1.0,29.9,"11760 Baltimore Ave, Beltsville, MD 20705","11760 Baltimore Ave, Beltsville, MD 20705"
-1.0,0.0,"7221 Sallie Mood Dr, Savannah, GA 31406","7221 Sallie Mood Dr, Savannah, GA 31406"
-1.0,0.0,"28270 Huntwood Ave, Hayward, CA 94544","28270 Huntwood Ave, Hayward, CA 94544"
-1.0,0.0,"903 Randolph St, Thomasville, NC 27360","903 Randolph St, Thomasville, NC 27360"
-1.0,0.0,"922 Highland Ave, Needham, MA 02494","922 Highland Ave, Needham, MA 02494"
-1.0,0.1,"2818 Neuse Blvd, New Bern, NC 28562","2818 Neuse Blvd, New Bern, NC 28562"
-1.0,0.0,"1199 Prince Ave, Athens, GA 30606","1199 Prince Ave, Athens, GA 30606"
-1.0,0.1,"6570 Bruton Smith Blvd, Concord, NC 28027","6570 Bruton Smith Blvd, Concord, NC 28027"
-1.0,0.0,"100 Hospital Dr, Bennington, VT 05201","100 Hospital Dr, Bennington, VT 05201"
-1.0,0.0,"600 Rhode Island Ave, Providence, RI 02908","600 Rhode Island Ave, Providence, RI 02908"
-1.0,0.0,"3702 2nd Ave, Columbus, GA 31904","3702 2nd Ave, Columbus, GA 31904"
-1.0,0.7,"935 N 1000 W, Tremonton, UT 84337","935 N 1000 W, Tremonton, UT 84337"
-1.0,0.6,"1000 Morris Ave, Union, NJ 07083","1000 Morris Ave, Union, NJ 07083"
-1.0,0.0,"500 Diamond Dr, Lake Elsinore, CA 92530","500 Diamond Dr, Lake Elsinore, CA 92530"
-1.0,0.2,"1 Medical Center Dr, Lebanon, NH 03766","1 Medical Center Dr, Lebanon, NH 03766"
-1.0,0.0,"147 Lake St, Newburgh, NY 12550","147 Lake St, Newburgh, NY 12550"
-1.0,0.1,"165 N University Ave, Farmington, UT 84025","165 N University Ave, Farmington, UT 84025"
-1.0,0.1,"4300 Rose Dr, Yorba Linda, CA 92886","4300 Rose Dr, Yorba Linda, CA 92886"
-1.0,0.1,"400 East Ave, Warwick, RI 02886","400 East Ave, Warwick, RI 02886"
-1.0,0.0,"1059 Canal St, Manchester, NH 03101","1059 Canal St, Manchester, NH 03101"
-1.0,0.0,"155 Glasson Way, Grass Valley, CA 95945","155 Glasson Way, Grass Valley, CA 95945"
-1.0,0.0,"800 W Meeting St, Lancaster, SC 29720","800 W Meeting St, Lancaster, SC 29720"
-1.0,1.4,"2384 N Memorial Dr, Lancaster, OH 43130","2384 N Memorial Dr, Lancaster, OH 43130"
-1.0,0.1,"2060 Sam Rittenberg Blvd, Charleston, SC 29407","2060 Sam Rittenberg Blvd, Charleston, SC 29407"
-1.0,0.1,"334 Carlisle Ave, York, PA 17404","334 Carlisle Ave, York, PA 17404"
-1.0,0.1,"1525 2100 S, Salt Lake City, UT 84119","1525 2100 S, Salt Lake City, UT 84119"
-1.0,0.0,"1280 E Stringham Ave, Salt Lake City, UT 84106","1280 E Stringham Ave, Salt Lake City, UT 84106"
-1.0,0.0,"4150 N 1st St, San Jose, CA 95134","4150 N 1st St, San Jose, CA 95134"
-1.0,0.1,"5126 W Daybreak Pkwy, South Jordan, UT 84009","5126 W Daybreak Pkwy, South Jordan, UT 84009"
-1.0,0.2,"100 Ter Heun Dr, Falmouth, MA 02540","100 Ter Heun Dr, Falmouth, MA 02540"
-1.0,0.1,"4801 Beckner Rd, Santa Fe, NM 87507","4801 Beckner Rd, Santa Fe, NM 87507"
-1.0,0.1,"1775 Dempster Street, Park Ridge, IL 60068","1775 Dempster Street, Park Ridge, IL 60068"
-1.0,0.0,"1743 Redstone Center Dr, Park City, UT 84098","1743 Redstone Center Dr, Park City, UT 84098"
-0.9958333333333332,0.0,"5850 Landerbrook Dr, Mayfield Heights, OH 44124","5850 Landerbrook Dr., Mayfield Heights, OH 44124"
-0.9958333333333332,0.0,"500 S Mt Olive St 200, Siloam Springs, AR 72761","500 S Mt Olive St #200, Siloam Springs, AR 72761"
-0.9952380952380953,0.1,"347 Don Shula Dr, Miami Gardens, FL 33056","347 Don Shula Dr., Miami Gardens, FL 33056"
-0.9952380952380953,0.0,"6125 W Sahara Ave 1B, Las Vegas, NV 89146","6125 W Sahara Ave #1B, Las Vegas, NV 89146"
-0.9951219512195122,0.0,"449 Kapahulu Ave 104, Honolulu, HI 96815","449 Kapahulu Ave #104, Honolulu, HI 96815"
-0.995,0.0,"2500 Hospital Dr, Martinsburg, WV 25401","2500 Hospital Dr., Martinsburg, WV 25401"
-0.9948717948717949,0.1,"1501 W Elk Ave, Elizabethton, TN 37643","1501 W. Elk Ave, Elizabethton, TN 37643"
-0.9948717948717949,0.2,"4201 N Dale Mabry Hwy, Tampa, FL 33607","4201 N Dale Mabry Hwy., Tampa, FL 33607"
-0.9948717948717949,0.0,"2400 Poplar Ave 501, Memphis, TN 38112","2400 Poplar Ave #501, Memphis, TN 38112"
-0.9948717948717949,0.0,"7495 W 29th Ave, Wheat Ridge, CO 80033","7495 W 29th Ave, Wheat Ridge, CO  80033"
-0.9947368421052633,0.0,"1 Medical Park Blvd, Bristol, TN 37620","1 Medical Park Blvd, Bristol, TN 37260"
-0.9947368421052633,0.0,"1415 California St, Houston, TX 77006","1415 California St., Houston, TX 77006"
-0.9947368421052633,0.0,"528 Delaware Ave, Palmerton, PA 18071","528 Delaware Ave., Palmerton, PA 18071"
-0.9945945945945945,0.0,"400 Keawe St 100, Honolulu, HI 96813","400 Keawe St #100, Honolulu, HI 96813"
-0.9945945945945945,0.0,"6441 High Star Dr, Houston, TX 77074","6441 High Star Dr, Houston, TX, 77074"
-0.9944444444444445,0.0,"1125 Shadow Ln, Las Vegas, NV 89102","1125 Shadow Ln, Las Vegas, NV, 89102"
-0.9942857142857143,0.1,"520 S Eagle Rd, Meridian, ID 83642","520 S. Eagle Rd, Meridian, ID 83642"
-0.9941666666666666,0.0,"46-021 Kamehameha Hwy, Kaneohe, HI 96744","46-21 Kamehameha Hwy, Kaneohe, HI 96744"
-0.9941176470588236,0.0,"3811 Lyons Ave, Houston, TX 77020","3811 Lyons Ave., Houston, TX 77020"
-0.9941176470588236,0.0,"450 N 11th St, Beaumont, TX 77702","450 N 11th St, Beaumont, TX, 77702"
-0.993939393939394,0.0,"7545 Main St, Woodstock, GA 30188","7545 Main St, Woodstock GA 30188"
-0.993939393939394,0.0,"9709 Bruton Rd, Dallas, TX 75217","9709 Bruton Rd., Dallas, TX 75217"
-0.9930232558139535,1.4,"100 Michigan St NE, Grand Rapids, MI 49503","1300 Michigan St NE, Grand Rapids, MI 49503"
-0.992,0.2,"325 N State of Franklin Rd, Johnson City, TN 37604","325 N State of Franklin Rd, Johnson City, TN 37614"
-0.9904761904761905,0.2,"4200 South Fwy 106, Fort Worth, TX 76115","4200 South Fwy. #106, Fort Worth, TX 76115"
-0.9897435897435898,0.0,"1655 W Main St, Stroudsburg, PA 18360","1655 W. Main St., Stroudsburg, PA 18360"
-0.9894736842105263,0.0,"7800 Preston Rd 300, Plano, TX 75024","7800 Preston Rd. #300, Plano, TX 75024"
-0.9891891891891892,0.0,"9991 Marsh Ln 100, Dallas, TX 75220","9991 Marsh Ln. #100, Dallas, TX 75220"
-0.9888888888888889,0.0,"3201 W Saner Ave, Dallas, TX 75233","3201 W. Saner Ave., Dallas, TX 75233"
-0.9888888888888889,0.1,"701 Grove Rd, Greenville, SC 29605","701 Grove Road, Greenville, SC 29605"
-0.9882352941176471,0.0,"123 Summer St, Worcester, MA 01604","123 Summer St, Worcester, MA 01608"
-0.9882352941176471,0.1,"800 E Park Blvd, Boise, ID 83712","800 E. Park Blvd., Boise, ID 83712"
-0.9860465116279069,0.1,"575 Pole Line Rd W, Twin Falls, ID 83301","575 Pole Line Rd. W., Twin Falls, ID, 83301"
-0.985,0.0,"2400 N Ashland Ave, Chicago, IL 60614","2400 N Ashland Avenue, Chicago, IL 60614"
-0.9842105263157895,0.0,"1500 Lansdowne Ave, Darby, PA 19023","1500 Lansdowne Avenue, Darby, PA 19023"
-0.9809415768576291,0.0,"209 Irish Cemetery Rd, Tazewell, TN 37879","209 Irish Cemetery Road, Tazewell, TN 37879"
-0.9804878048780488,0.1,"757 Westwood Plaza, Los Angeles, CA 90024","757 Westwood Plaza, Los Angeles, CA 90095"
-0.9799874921826142,0.1,"4201 Winfield Rd, Warrenville, IL 60555","4201 Winfield Road, Warrenville, IL 60555"
-0.9783533765032377,0.0,"7213 Old Alexandria Ferry Rd, Clinton, MD 20735","7213 Old Alexandria Ferry Rd Clinton, MD 20735"
-0.9780780780780781,0.1,"400 Putnam Pike, Smithfield, RI 02917","400 Putnam Pike  Smithfield, RI 02917"
-0.9778658536585366,0.7,"9800 International Dr, Orlando, FL 32819","9400 International Dr, Orlando, FL, 32819"
-0.9761029411764706,0.0,"10300 SW 216th St, Miami, FL 33190","10300 SW 216 ST, Miami, FL 33190"
-0.9759969028261711,0.8,"289 McClellandtown Rd, Uniontown, PA 15401","86 McClellandtown Rd, Uniontown, PA 15401"
-0.9757575757575758,0.0,"16045 1st Ave S, Burien, WA 98166","16045 1st Ave S, Burien, WA 98148"
-0.9754990925589837,0.0,"601 Dr Martin Luther King Jr Ave NE, Albuquerque, NM 87102","601 Dr Martin Luther King Jr Ave NE Albuquerque, NM 87102"
-0.9747619047619047,0.4,"10 Sunnybrook Rd, Raleigh, NC 27610","111 Sunnybrook Rd, Raleigh, NC 27610"
-0.9741891891891892,0.0,"1325 Jefferson Ave, Memphis, TN 38104","1325 Jefferson Avenue, Memphis, TN 38104"
-0.9738191632928476,0.0,"5366 Mendenhall Mall, Memphis, TN 38115","5366 Mendenhall Mall Memphis, TN 38115"
-0.9735483870967742,0.0,"777 N Main St, Tooele, UT 84074","777 N Main St Tooele, UT 84074"
-0.9735042735042735,0.0,"1440 E Butler Pike, Ambler, PA 19002","1440 East Butler Pike, Ambler, PA 19002"
-0.9733997155049786,0.1,"6430 Hillcroft Ave, Houston, TX 77074","6430 Hillcroft Ave, Houston, TX, 77081"
-0.9732330827067669,0.0,"31 Physicians Dr, Jackson, TN 38305","31 Physicians Drive, Jackson, TN 38351"
-0.9726436781609196,0.0,"1397 Weimer Rd, Taos, NM 87571","1397 Weimer Rd Taos, NM 87571"
-0.9723723723723724,0.0,"100 E Michigan Ave, Jackson, MI 49201","100 E Michigan Ave Jackson, MI 49201"
-0.9721227621483376,0.0,"2330 S Congress Ave, West Palm Beach, FL 33406","2330 S Congress Ave, West Palm Beach, Florida 33406"
-0.9720190779014308,0.0,"100 Hospital Dr, Ketchum, ID 83340","100 Hospital Drive, Ketchum, ID 83340"
-0.9719047619047619,0.0,"510 W Tidwell Rd, Houston, TX 77076","510 W Tidwell Rd, Houston, TX, 77091"
-0.9715873015873016,0.0,"118 Northport Ave, Belfast, ME 04915","118 Northport Ave Belfast, ME 04915"
-0.9714098972922501,0.0,"1131 Warwick Ave, Warwick, RI 02888","1131 Warwick Ave.  Warwick, RI 02888"
-0.9712418300653595,0.1,"3249 N 1200 W Ste. A, Lehi, UT 84043","3249 N 1200 W Ste A Lehi, UT 84043"
-0.9708478513356562,0.1,"4771 S Cleveland Ave, Fort Myers, FL 33907","4771 S Cleveland Av, Fort Myers, FL 33907"
-0.97056786350904,0.0,"67 Valley Rd, Middletown, RI 02842","67 Valley Rd.  Middletown, RI 02842"
-0.9702439024390244,0.1,"400 W Mineral King Ave, Visalia, CA 93291","400 W Mineral King Ave. Visalia, CA 93291"
-0.9700534759358289,0.1,"914 Shorter Ave NW, Rome, GA 30165","914 Shorter Ave NW; Rome, GA 30165"
-0.9700000000000001,0.2,"263 Farmington Ave, Farmington, CT 06032","263 Farmington Ave, Farmington, CT"
-0.969676994067238,0.2,"300 Enterprise Dr, Kingston, NY 12401","300 Enterprise Drive, Kingston, NY, 12401"
-0.969449715370019,0.0,"200 Hygeia Dr, Newark, DE 19713","200 Hygeia Drive, Newark, DE 19713"
-0.9693589743589744,0.0,"169 Westmoreland St, Harrogate, TN 37752","169 Westmoreland St Harrogate, TN 37752"
-0.9689393939393939,0.1,"1501 Hiland Ave, Burley, ID 83318","1501 Hiland Ave Burley, ID 83318"
-0.9686909581646423,0.0,"6812 Harrisburg Blvd, Houston, TX 77011","6812 Harrisburg Blvd. Houston, TX 77011"
-0.9685560053981107,0.1,"55 Meadowlands Pkwy, Secaucus, NJ 07094","55 Meadowlands Pkwy Secaucus, NJ 07094"
-0.9682828282828283,0.0,"2400 N Washington Blvd, North Ogden, UT 84414","2400 N Washington Blvd North Ogden, UT 84414"
-0.9682828282828283,0.0,"2975 Maynardville Hwy, Maynardville, TN 37807","2975 Maynardville Hwy Maynardville, TN 37807"
-0.9679435483870968,0.0,"525 N Main St, Ephraim, UT 84627","525 N Main St Ephraim, UT 84627"
-0.9679435483870968,0.0,"300 Wilson St, Clayton, NM 88415","300 Wilson St Clayton, NM 88415"
-0.9671826625386997,0.2,"602 Indiana Ave, Lubbock, TX 79415","602 Indiana Avenue, Lubbock, TX, 79415"
-0.967016317016317,0.0,"2116 Jackson Blvd, Rapid City, SD 57702","2116 Jackson Boulevard, Rapid City, SD 57702"
-0.9667774086378738,0.0,"9621 Ridgetop Blvd NW, Silverdale, WA 98383","9621 Ridgetop Blvd NW Silverdale, WA 98383"
-0.9658730158730159,0.1,"600 Gillmor Way, Park City, UT 84060","600 Gillmor Way Park City, UT 84060"
-0.9654761904761905,0.1,"1000 N Main St Ste. A, Richfield, UT 84701","1000 N Main St Ste A Richfield, UT 84701"
-0.9652777777777778,0.2,"111 Gateway Center Dr, Kernersville, NC 27284","111 Gateway Center Drive, Kernersville, NC 27284"
-0.9652014652014652,0.0,"7401 Ogontz Ave, Philadelphia, PA 19138","7401 Ogontz Avenue, Philadelphia, PA 19138"
-0.9641025641025641,0.2,"5201 Harry Hines Blvd, Dallas, TX 75390","5200 Harry Hines Blvd, Dallas, TX 75235"
-0.964102564102564,0.0,"13 Medical Campus Dr, , NC 28462","13 Medical Campus Dr., Supply, NC 28462"
-0.9638383838383838,0.0,"1721 Rio Rancho Blvd SE, Rio Rancho, NM 87124","1721 Rio Rancho Blvd. SE Rio Rancho, NM 87124"
-0.9638146167557933,0.0,"1010 Spruce St, Española, NM 87532","1010 Spruce St Española, NM 87532"
-0.9638146167557933,0.1,"6 Glen Cove Dr, Rockport, ME 04856","6 Glen Cove Dr Rockport, ME 04856"
-0.9633783783783784,0.0,"15214 Canyon Rd E, Puyallup, WA 98375","15214 Canyon Road E., Puyallup, WA 98375"
-0.9630021141649049,0.0,"13701 Encantado Rd NE, Albuquerque, NM 87123","13701 Encantado Rd. NE Albuquerque, NM 87123"
-0.9629629629629629,0.5,"400 W Maple St, Farmington, NM 87401","801 W Maple St, Farmington, NM 87401"
-0.9628787878787879,0.0,"555 N Broadway, Jericho, NY 11753","555 N. Broadway Jericho, NY 11753"
-0.9625,0.2,"775 Norman Dr, Lebanon, PA 17042","720 Norman Dr, Lebanon, PA 17042"
-0.9625,0.1,"130 Division St, Derby, CT 06418","130 Division St, Derby, CT"
-0.9623044096728307,0.0,"433 Fairview Ave, Ponca City, OK 74601","433 Fairview Ave Ponca City, OK 74601"
-0.9620364550597109,0.0,"200 SE Hospital Ave, Stuart, FL 34994","200 SE Hospital Ave., Stuart, Florida 34994"
-0.9612612612612612,0.0,"3845 W 4700 S, Taylorsville, UT 84129","3845 W 4700 S Taylorsville, UT 84129"
-0.9610483870967742,0.4,"300 Pompton Rd, Wayne, NJ 07470","300 Pompton Road Wayne, NJ 07470"
-0.9606177606177606,0.0,"6451 Village Ln, Macungie, PA 18062","6451 Village Lane, Macungie, PA 18062"
-0.9604761904761904,0.0,"3250 Alpine Rd, Portola Valley, CA 94028","3250 Alpine Road, Portola Valley, CA 94028"
-0.9601587301587302,0.0,"577 S River Rd, St. George, UT 84790","577 S River Rd St. George, UT 84790"
-0.9601219512195123,0.3,"300 Wendover Ave E, Greensboro, NC 27401","300 E. Wendover Ave, Greensboro, NC 27401"
-0.96,0.1,"5917 Belt Line Rd, Dallas, TX 75254","5917 Belt Line Rd, Dallas TX"
-0.9599613152804642,0.1,"1 TIAA Bank Field Dr, Jacksonville, FL 32202","1 TIAA Bank Field Drive, Jacksonville, FL 32202"
-0.9592171717171717,0.0,"933 W Race St, Kingston, TN 37763","933 W Race Street Kingston, TN 37763"
-0.9591025641025642,0.0,"556 Passaic Ave, West Caldwell, NJ 07006","556 Passaic Ave West Caldwell, NJ 07006"
-0.9580808080808082,0.1,"615 Prospect Ave, Springer, NM 87747","615 Prospect Ave, Springer, New Mexico 87747"
-0.9579322638146167,0.0,"104 Legion Dr, Las Vegas, NM 87701","104 Legion Dr. Las Vegas, NM 87701"
-0.9577540106951872,0.1,"5450 GA-20, Cartersville, GA 30121","5450 GA-20 Cartersville, GA 30121"
-0.9577540106951872,0.1,"762 W 400 S, Springville, UT 84663","762 W 400 S Springville, UT 84663"
-0.9575757575757576,0.0,"82-68 164th St, , NY 11432","82-68 164th St, Jamaica, NY 11432"
-0.956987756987757,0.0,"1010 Higbee Dr, Bethel Park, PA 15102","1010 Higbee Drive Bethel Park, PA 15102"
-0.9567251461988304,0.4,"3109 Wrightsboro Rd, Augusta, GA 30909",3109 Wrightsboro Road Augusta GA 30909
-0.9564393939393939,0.0,"962 Sage Dr, Cedar City, UT 84720","962 Sage Dr Cedar City, UT 84720"
-0.9563888888888888,0.1,"600 Highland Oaks Dr, Winston-Salem, NC 27103","600 Highland Oaks Drive, Winston-Salem, NC 27103"
-0.9563888888888888,0.0,"2121 Industrial Pkwy, Silver Spring, MD 20904","2121 Industrial Parkway, Silver Spring, MD 20904"
-0.956060606060606,0.0,"4220 William Penn Hwy, Monroeville, PA 15146","4220 William Penn Highway, Monroeville, PA 15146"
-0.9548333333333333,0.0,"5150 Journal Center Blvd NE, Albuquerque, NM 87109","5150 Journal Center Blvd. SE Albuquerque, NM 87109"
-0.9535353535353536,0.2,"3250 Meridian Pkwy, Weston, FL 33331","3250 Meridian Parkway, Weston, Florida 33331"
-0.9529411764705882,0.1,"79-01 Broadway, , NY 11373","79-01 Broadway, Elmhurst, NY 11373"
-0.9525675675675677,1.5,"365 Montauk Ave, New London, CT 06320","365 Montauk Avenue, New London, CT 06320"
-0.9523861236802413,0.0,"1344 Wintergreen Ln NE, Bainbridge Island, WA 98110","1344 Wintergreen Lane NE Bainbridge Island, WA 98110"
-0.9522222222222222,239.2,"140 N Sherman Ct, Hazleton, PA 18201","140 N. Sherman Court, Hazleton, PA 18201"
-0.951207729468599,0.1,"1320 Travis Blvd Suite C, Fairfield, CA 94533","1320 Travis Blvd, Suite C, Fairfield, CA 94533"
-0.9501501501501503,0.0,"389 S 900 E, Salt Lake City, UT 84102","389 S 900 E Salt Lake City, UT 84102"
-0.9500189753320682,0.0,"1030 Main St, Waltham, MA 02451","1030 Main Street, Waltham MA 02451"
-0.9499511241446726,0.0,"1601 Trinity St, Austin, TX 78701","1601 Trinity St. Austin, Tx 78701"
-0.9486587011619104,0.0,"10 Montgomery Dr, Arkadelphia, AR 71923","10 Montgomery Drive, Arkadelphia AR 71923"
-0.9482536011947776,0.0,"12311 Perry Hwy, Wexford, PA 15090","12311 Perry Highway Wexford, PA 15090"
-0.9476623376623377,0.0,"3280 E Lanark St, Meridian, ID 83642","3280 E Lanark Dr Meridian, ID 83642"
-0.9475478927203065,0.0,"254-61 Nassau Blvd, , NY 11362","254-61 Nassau Blvd. Queens, NY 11362"
-0.9471198471198472,0.0,"3122 E Meridian Park Loop, Wasilla, AK 99654","3122 E Meridian Park Lp.  Wasilla, AK"
-0.9470449172576832,0.0,"146 Passion Play Rd, Eureka Springs, AR 72632","146 Passion Play Rd b, Eureka Springs, AR 72632"
-0.9464285714285714,0.0,"625 W 12th St, Wilmington, DE 19801","625 W. 12th Street, Wilmington, DE 19801"
-0.9456535644030364,0.0,"132 5th Ave W Suite 1 & 2, Jerome, ID 83338","132 5th Ave. W. Suites 1 and 2 Jerome, ID 83338"
-0.9453510436432637,0.0,"700 Caldwell Blvd, Nampa, ID 83651","700 Caldwell Blvd. Nampa, ID 83686"
-0.9452017648680945,0.1,"2570 Riverside Pkwy, Lawrenceville, GA 30046","2570 Riverside Parkway Lawrenceville, GA 30046"
-0.945,0.0,"2741 MacArthur Rd, , PA 18052","2741 MacArthur Road, Whitehall, PA 18052"
-0.9447104247104247,0.2,"700 Halia Nakoa St, Wailuku, HI 96793","700 Halia Nakoa Street, Wailuku, HI"
-0.9446241995281429,0.0,"5133 Rivers Ave, North Charleston, SC 29406","5133 Rivers Avenue North Charleston, SC  29406"
-0.9441145281018027,0.1,"701 E Marshall St, West Chester, PA 19380","701 E. Marshall Street, West Chester, PA 19380"
-0.943939393939394,0.0,"1919 College Dr, Gallup, NM 87301","1919 College Drive, Gallup, New Mexico 87301"
-0.9432609079667903,0.0,"2805 Overseas Hwy, Marathon, FL 33050","2805 Overseas HWY Marathon, FL 33050"
-0.9428571428571428,0.1,"1400 Pelham Pkwy S, , NY 10461","1400 Pelham Parkway South, Bronx, NY 10461"
-0.9420190779014309,0.3,"1120 W State Fair Ave, Detroit, MI 48203","1120 W State Fair Avenue, Detroit, MI"
-0.9418103448275862,0.4,"1830 Katyland Dr, Katy, TX 77493","1830 Katyland Drive, Katy, TX"
-0.9397515527950311,0.0,"19600 Vallco Pkwy 170, Cupertino, CA 95014","19600 Vallco Pkwy Ste 170, Cupertino, CA 95014"
-0.9396203796203796,0.1,"919 Murfreesboro Rd, Franklin, TN 37064","919 Murfreesboro Road, Franklin, TN"
-0.9393892339544514,0.0,"2122 N Scottsdale Rd, Scottsdale, AZ 85257","2122 N Scottsdale Rd Scottsdale, Arizona 85257"
-0.9392329239388063,0.1,"115 Porter Dr, Middlebury, VT 05753","115 Porter Drive  Middlebury, VT  05753"
-0.9392329239388063,0.1,"30 Locust St, Northampton, MA 01060","30 Locust Street, Northampton, MA 01061"
-0.9388384754990925,0.2,"105 Pearl St, Essex, VT 05452","105 Pearl St, Essex Junction, VT 05452"
-0.9376847745750185,0.0,"98-199 Kamehameha Hwy Bldg F, Aiea, HI 96701","98-199 Kamehameha hwy building f, Aiea, HI 96701"
-0.9373868091454741,0.1,"3723 W 12600 S 150, Riverton, UT 84065","3723 W 12600 S Ste 150 Riverton, UT 84065"
-0.937140763849499,0.0,"9494 W Northern Ave 101, Glendale, AZ 85305","9494 W Northern Ave #101 Glendale, Arizona 85305"
-0.9370637536491194,0.0,"5920 W McDowell Rd, Phoenix, AZ 85035","5920 W McDowell Rd Phoenix, Arizona 85035"
-0.9369953543152523,0.0,"1000 State St, McCall, ID 83638","1000 State St. McCall, Idaho 83638"
-0.9363924963924964,0.3,"215 Applegarth Rd, Monroe Township, NJ 08831","215 Applegarth Road Monroe, NJ 08831"
-0.9356623669123669,0.0,"315 W Main St, Freehold, NJ 07728","315 W. Main Street Freehold, NJ 07728"
-0.9346195949644225,0.0,"9450 1300 E, Sandy, UT 84094","9450 S 1300 E Sandy, UT 84094"
-0.9333553065260383,0.5,"125 Michigan Ave NE, Washington, DC 20017","111 Michigan Ave NW, Washington, DC 20010"
-0.9326640926640927,0.2,"2424 W Jefferson St, Joliet, IL 60435","2424 West Jefferson, Joliet, IL 60435"
-0.9319815668202764,0.2,"200 N 400 E St, Panguitch, UT 84759","200 N 400 E Panguitch, UT 84759"
-0.9317307692307691,0.1,"201 King of Prussia Rd, Wayne, PA 19087","250 King of Prussia Rd, Radnor, PA 19087"
-0.9315208825847123,0.0,"1679 E Monte Vista Ave 104, Vacaville, CA 95688","1679 E Monte Vista Ave, Suite 104, Vacaville, CA 95688"
-0.9304263777947989,0.1,"181 Medical Tower Dr, Murray, UT 84107","181 E Medical Tower Dr Murray, UT 84107"
-0.9298654244306418,0.0,"2025 Glenn Mitchell Dr, Virginia Beach, VA 23456","2025 Glenn Mitchell Drive Virginia Beach, Virginia 23456"
-0.9294771241830065,0.0,"18589 N 59th Ave, Glendale, AZ 85308","18589 N 59th Ave Glendale, Arizona 85308"
-0.9294276094276094,0.1,"2131 Industrial Pkwy, Silver Spring, MD 20904","2121 Industrial Parkway, Silver Spring, MD 20904"
-0.9293290043290043,0.0,"1701 E Thomas Rd, Phoenix, AZ 85016","1701 E Thomas Rd. Phoenix, Arizona 85016"
-0.9293290043290043,0.0,"1860 N Church Rd, Liberty, MO 64068","1860 N Church Rd Liberty, Missouri 64068"
-0.9291150709755361,0.0,"2075 University Park Blvd, Layton, UT 84041","2075 N University Park Blvd Layton, UT 84041"
-0.9286763686763687,0.2,"2245 Callaway Rd SW, Marietta, GA 30008","2245 Callaway Road Marietta, GA 30008"
-0.9280172413793103,0.0,"320 W Pumping Station Rd 3, Quakertown, PA 18951","320 W. Pumping Station Road, Suite 3, Quakertown, PA 18951"
-0.9274991674991675,0.0,"600 S Dobson Rd, Chandler, AZ 85224","600 S Dobson Rd Chandler, Arizona 85224"
-0.927433155080214,5.3,"264 W 118th St, New York, NY 10026","216 E 14th St, New York, NY 10003"
-0.9270609318996416,0.1,"4247 W Ridge Rd, Erie, PA 16506","4247 West Ridge Road, Erie, PA 16506"
-0.9268855368234251,0.0,"1150 W El Camino Real, Mountain View, CA 94040","1150 West El Camino Real, Mountain View, CA 94040"
-0.9262539568057058,0.0,"3181 SW Sam Jackson Park Rd, Portland, OR 97239","3181 S.W. Sam Jackson Park Road Portland, Oregon 97239-3098"
-0.9259999999999999,0.0,"800 Weatherly Dr 201B, Clarksville, TN 37043","800 Weatherly Dr Suite 201B, Clarksville, TN 37043"
-0.9247902265118908,0.0,"6030 S 66th E Ave, Tulsa, OK 74145","6030 S 66th East Avenue, Tulsa, Ok, 74145"
-0.9221611721611722,0.0,"1998 Market St, SF, CA 94102","1998 Market St, San Francisco, CA 94102"
-0.9218487394957984,0.0,"1691 Galisteo St Ste D, Santa Fe, NM 87505","1691 Galisteo St, Ste D, Santa Fe, New Mexico 87505"
-0.9208372093023256,0.0,"254 Ren Mar Dr 100, Pleasant View, TN 37146","254 Ren Mar Dr, Suite 100, Pleasant View, TN 37146"
-0.9207459207459208,0.1,"1475 W 49th Pl, Hialeah, FL 33012","1475 West 49th Place, Hialeah, FL 33012"
-0.9201851851851851,0.1,"777 Seaview Ave, , NY 10305","777 Seaview Ave, Staten Island, NY 10305"
-0.9200956937799044,0.0,"3025 W Cherry Ln B, Meridian, ID 83642","3025 West Cherry Lane #B, Meridian, ID 83642"
-0.919751218183469,0.0,"2350 Schillinger Rd S Suite A, Mobile, AL 36695","2350 Schillinger Rd., Mobile, AL 36695"
-0.919675417043838,0.0,"330 N Eisenhower Dr, Beckley, WV 25801","330 North Eisenhower Drive Beckley, WV 25801"
-0.9186679174484051,0.0,"7131 Frankford Ave 2nd Floor, Philadelphia, PA 19135","7131 Frankford Ave Philadelphia, PA 19135"
-0.9177766032417195,0.0,"1400 Jackson St, Denver, CO 80206","1400 Jackson Street, Denver, Colorado 80206"
-0.9176624442279091,0.0,"280 Home Olu Pl, Kaunakakai, HI 96748","280 Home Olu Place, Kaunakakai, HI"
-0.9173061173061173,2.7,"540 Litchfield St, Torrington, CT 06790","540 Litchfield Street, Torrington, CT"
-0.9173061173061173,0.1,"67-1125 Mamalahoa Hwy, Waimea, HI 96743","67-1125 Mamalahoa Highway, Waimea, HI"
-0.9162280701754385,0.0,"4910 Fairfield Rd, Fairfield, PA 17320","4910 Fairfield Rd. , Suite A Fairfield, PA 17320"
-0.9162004662004662,0.0,"1100 N 4th St, Leavenworth, KS 66048","1100 N 4th St Leavenworth, Kansas 66042"
-0.9160687138948009,0.0,"7305 N Military Trl, Riviera Beach, FL 33410","7305 N Military Trl, West Palm Beach, FL 33410"
-0.9160224089635854,0.0,"1730 W Chew St, Allentown, PA 18104","1730 Chew St., Allentown, PA 18104"
-0.9154761904761906,0.0,"4700 Rice Mine Rd NE, Tuscaloosa, AL 35406","4700 Rice Mine Road Northeast Tuscaloosa, AL 35406"
-0.9148325358851676,0.1,"4280 N Valdosta Rd, Valdosta, GA 31602","4280 North Valdosta Road, Valdosta, GA 31602"
-0.9147749042145594,0.1,"5 Perryridge Rd, Greenwich, CT 06830","5 Perryridgy Road, Greenwich, CT"
-0.9147619047619048,0.1,"34 Maple St, Norwalk, CT 06850","34 Maple Street, Norwalk, CT"
-0.9140316205533596,0.4,"703 Buena Vista Blvd, The Villages, FL 32162","703 N Buena Vista Blvd, The Villages, FL 32162"
-0.9129124820659972,0.0,"1233 W Poplar St, Rogers, AR 72756","1233 West Poplar Street, Rogers, AR 72756"
-0.9121510673234811,0.0,"5 Alumni Dr, Exeter, NH 03833","5 Alumni Drive Exeter, New Hampshire 03833"
-0.9110411140583554,0.6,"435 Lewis Ave, Meriden, CT 06451","435 Lewis Avenue, Meriden, CT"
-0.910952380952381,0.0,"5601 W Chinden Blvd, Garden City, ID 83714","5601 W.Chinden Blvd. Garden City, ID 83714"
-0.9107342657342657,0.0,"450 Northcrest Dr, Springfield, TN 37172","450 North Crest Drive, Springfield, TN 37172"
-0.9084848484848485,0.1,"940 Oldham Dr, Nolensville, TN 37135","940 Oldham Drive, Nolensville, TN"
-0.908265306122449,0.1,"292 Frantz Rd 102, Stroudsburg, PA 18360","292 Frantz Road, Suite 102, Stroudsburg, PA 18360"
-0.9072079772079772,0.0,"1225 Gerard Ave, , NY 10452","1225 Gerard Avenue Bronx, New York 10452"
-0.907001223990208,0.0,"5501 Herrera Drive, Santa Fe, NM 87505","5501 Herrera Dr. Santa Fe, New Mexico 87507"
-0.9067498165810711,0.0,"900 Carillon Pkwy 106, St. Petersburg, FL 33716","900 Carillon Parkway, Suite. 106, St. Petersburg, FL 33716"
-0.9060728744939271,0.1,"234 E 149th St, , NY 10451","234 East 149th Street, Bronx, NY 10451"
-0.9051272324956535,0.0,"211 Quarry Rd 102, Palo Alto, CA 94304","211 Quarry Road Suite 102 Palo Alto, CA 94304"
-0.9049308755760368,0.1,"150 Sargent Dr, New Haven, CT 06511","150 Sargent Drive, New Haven CT"
-0.903968105065666,0.0,"450 S Kitsap Blvd, Port Orchard, WA 98366","450 S. Kitsap Blvd. Suite 100 Port Orchard, WA 98366"
-0.9027642276422764,0.3,"1630 Rio Rancho Blvd SE, Rio Rancho, NM 87124","1721 Rio Rancho Blvd. SE Rio Rancho, NM 87124"
-0.900904071773637,0.0,"2950 S 6th St, Springfield, IL 62703","2950 South Sixth Street, Springfield, IL 62703"
-0.9007928749864234,0.1,"1000 Main St, Stratford, CT 06615","1000 Main Street, Stratford, CT"
-0.9007325360751952,0.3,"10251 Central Ave, Upper Marlboro, MD 20772","10251 Central Ave, Largo, MD 20774"
-0.9005478022694666,0.1,"147 S Main St, Middleton, MA 01949","147 South Main Street Middleton, MA 01949"
-0.8998563141929647,0.0,"5251 W. U.S. Hwy 290 Ste 200, Austin, TX 78735","5251 West, US-290 Ste 200, Austin, TX 78735"
-0.8998051948051948,4.0,"201 Chestnut Hill Rd, Stafford, CT 06076","201 Chestnut Hill Road, Stafford Springs, CT"
-0.899553128103277,0.1,"3098 Campbell Station Pkwy 100, Spring Hill, TN 37174","3098 Campbell Station Parkway, Suite 100, Spring Hill, TN"
-0.8977885891198584,0.1,"4534 Harding Pike, Nashville, TN 37205","4534 Harding Pike, Belle Meade, TN"
-0.8972480220158238,0.2,"35 S Sillyman St, Cressona, PA 17929","35 Sillyman Street, Cressona, PA 17929"
-0.8968487394957984,0.5,"2979 Main St, Bridgeport, CT 06606","2979 Main Street, Bridgeport, CT"
-0.8968487394957984,0.0,"267 Grant St, Bridgeport, CT 06610","267 Grant Street, Bridgeport, CT"
-0.8943312321260125,0.1,"27 S Cooks Bridge Rd Suite 1-5, Jackson Township, NJ 08527","27 S Cooksbridge Road Suite 1-5 Jackson, NJ 08527"
-0.8929411764705882,0.0,"4455 US-36 East, Decatur, IL 62521","4455 E. U.S. 36, Decatur, IL 62521"
-0.8924475524475525,0.1,"33 Tower St, Somerville, MA 02143","33 Tower Street, Somerville MA"
-0.891986271986272,0.1,"300 Steam Plant Rd 430, Gallatin, TN 37066","300 Steam Plant Road, Suite 430, Gallatin, TN"
-0.8917396745932415,0.0,"1071 MD-3 101, Gambrills, MD 21054","1071 MD-3 North, Suite 101, Gambrills, MD 21054"
-0.8898039215686275,0.0,"2040 NJ-33, Neptune City, NJ 07753","2040 Route 33 Neptune City, NJ 07753"
-0.889693313222725,0.0,"701 U.S. 9, Lacey Township, NJ 08731","701 U.S. 9, Forked River, NJ 08731"
-0.8891278375149343,0.0,"714 10th St, Secaucus, NJ 07094","714 Tenth St.Secaucus, NJ 07094"
-0.8884615384615385,0.1,"760 Broadway, , NY 11206","760 Broadway, Brooklyn, NY"
-0.888414505587181,1.3,"227 Madison St, New York, NY 10002","24 Broad St, New York, NY 10005"
-0.8882882882882882,1.1,"3301 N Ashland Ave, Chicago, IL 60657","2400 N Ashland Avenue, Chicago, IL 60614"
-0.8881596452328159,0.0,"3120 Burnet Ave 406, Cincinnati, OH 45229","3120 Burnet Ave, Cincinnati, Ohio"
-0.8874684343434343,5.5,"3362 S 3rd St, Memphis, TN 38109","364 S Front St, Memphis, TN 38103"
-0.8859986772486772,3.9,"1000 Asylum Ave, Hartford, CT 06105","1000 Asylum Street, Hartford, CT"
-0.8858730158730159,0.0,"2925 River Rd S 110, Salem, OR 97302","2925 River Road S. Suite 110, Salem, Oregon 97302"
-0.883511586452763,0.1,"36245 US-27, Haines City, FL 33844","36245 U.S. Highway 27, Haines City, FL 33844"
-0.8826623376623377,0.0,"1834 W McEwen Dr 110, Franklin, TN 37067","1834 W McEwen Drive, Suite 110, Franklin, TN"
-0.8811301072152999,0.1,"2102 E Archer Rd, Baytown, TX 77521","2102 East Archer Road, Baytown, TX"
-0.8810653293575496,0.2,"450 IL-22, Barrington, IL 60010","450 W Hwy 22, Barrington, IL 60010"
-0.8785706527642012,0.1,"4088 US-91, Hyde Park, UT 84318","4088 N HWY 91 Hyde Park, UT 84318"
-0.8772351421188631,0.1,"1801 S Edwin C Moses Blvd, Dayton, OH 45417","1801 Edwin C. Moses Blvd, Dayton, OH"
-0.875383718337878,0.2,"400 W 7th St, Frederick, MD 21701","501 W. 7th Street, Frederick, MD 21701"
-0.8717948717948718,0.0,"1485 US-40 Ste. G, Heber City, UT 84032","1485 S Highway 40 Ste G Heber, UT 84032"
-0.8702210070631123,0.0,"134 Pewitt Dr 200, Brentwood, TN 37027","134 Pewitt Drive, Suite 200, Brentwood, TN"
-0.8692161166093835,0.3,"9400 Universal Blvd, Orlando, FL 32819","9400 International Dr, Orlando, FL, 32819"
-0.8690570475436197,0.1,"4911 Sandhill Dr, Sugar Land, TX 77479","4907 Sandhill Drive Sugar Land, Texas 77479"
-0.8689149015235972,0.0,"2536 TN-49 110, Pleasant View, TN 37146","2536 Hwy 49, Suite 110 Pleasant View, TN 37146"
-0.865,2.1,"1201 NW 16th St, Miami, FL 33125","1350 NW 50 ST, Miami, FL 33142"
-0.8626192480359148,3.9,"2300 S 16th St, Lincoln, NE 68502","555 S 70th St, Lincoln, NE 68510"
-0.8605867620751342,0.0,"545 E 142nd St, , NY 10454","545 East 142nd Street Bronx, New York 10454"
-0.8601876172607881,0.0,"2608 8th Ave S 102A, Berry Hill, TN 37204","2608 8th Ave S, Suite 102A, Melrose, TN"
-0.8592709359605911,0.1,"700 UT-99, Fillmore, UT 84631","700 S Highway 99 Fillmore, UT 84631"
-0.8591964285714284,42.1,"1 Medical Center Dr, Biddeford, ME 04005","123 Medical Center Dr, Brunswick, ME 04011"
-0.8591446504159977,0.1,"7069 Hwy 70 S, Nashville, TN 37221","7069 Highway 70 S, Bellevue, TN"
-0.8590959609827534,0.0,"700 Roosevelt Ave 100, Grants, NM 87020","700 E. Roosevelt, Suite 100, Grants, New Mexico 87020"
-0.8590716581584421,0.0,"4700 Point Fosdick Dr, Gig Harbor, WA 98335","4700 Pt. Fosdick Drive N.W., Suite 102, Gig Harbor, WA 98335"
-0.8576190476190476,6.5,"56 Franklin St, Waterbury, CT 06706","56 Franklin Street, Waterbury, Connecticut"
-0.8556390977443609,12.4,"7211 N Interstate 35 Frontage Rd, Austin, TX 78752","7211 N. IH35 Frontage Road, Austin, TX"
-0.8537151702786377,0.0,"750 Broadway 250, Fort Wayne, IN 46802","700 Broadway, Fort Wayne, IN 46802"
-0.8535788923719958,1.8,"2140 Mendon Rd, Cumberland, RI 02864","2 Meehan Ln, Cumberland, RI 02864"
-0.8528769841269841,78.3,"1600 Divisadero St, SF, CA 94115","1600 Exposition Blvd, Sacramento, CA 95815"
-0.851867816091954,0.0,"1812 S J St, Tacoma, WA 98405","1812 South J Street, Suite 120, Tacoma, WA 98405"
-0.8513247592943988,0.6,"462 1st Avenue, New York, NY 10016","561 3rd Ave, New York, NY 10016"
-0.8485380116959065,4.4,"10010 Kennerly Rd, St. Louis, MO 63128","4400 Telegraph Rd, St. Louis, MO 63129"
-0.8380933062880325,0.0,"300 8th St, Estancia, NM 87016","300 South Eighth Street, Estancia, New Mexico 87016"
-0.8377610693400167,0.2,"10101 S 27th St, Franklin, WI 53132","9969 South 27th St, Franklin, WI 53132"
-0.8377142857142857,43.0,"500 Lincoln St, Worcester, MA 01605","500 Lynnfield Street Lynn, MA 01904"
-0.8376310313182623,0.7,"1600 W 22nd St, Sioux Falls, SD 57105","2501 W. 22nd Street Sioux Falls, SD 57105"
-0.8332917156286722,17.6,"401 NW 42nd Ave, Plantation, FL 33317","401 E 65th ST, Hialeah, FL 33013"
-0.8319917582417582,1.6,"1901 1st Avenue, New York, NY 10029","1150 3rd Ave, New York, NY 10065"
-0.8294067093409199,2.8,"915 N Grand Blvd, St. Louis, MO 63106","3114 S Grand Blvd, St. Louis, MO 63118"
-0.8289972899728998,2.3,"4900 Frankford Ave, Philadelphia, PA 19124","7131 Frankford Ave Philadelphia, PA 19135"
-0.8263814616755794,16.5,"128 W 14th St, Hazleton, PA 18201","128 E Main St, Nanticoke, PA 18634"
-0.8257888657888658,26.0,"273 Teaticket Hwy, Falmouth, MA 02536","275 Sandwich Street, Plymouth, MA 02360"
-0.825219421101774,2.0,"1 Elliot Way, Manchester, NH 03103","1059 Canal St, Manchester, NH 03101"
-0.8249019607843138,148.4,"4014 S Lamar Blvd, Austin, TX 78704","401 Branard St., Houston, TX 77006"
-0.8247354497354497,0.8,"411 Grand Ave, Oakland, CA 94610","3850 Grand Avenue  Oakland, CA 94610"
-0.8239018087855298,45.8,"123 W Manchester Blvd, Inglewood, CA 90301","1233 Rancho Vista Blvd., Palmdale, CA 93551"
-0.8215883371055785,50.3,"145 W University Pkwy, Orem, UT 84058","165 N University Ave, Farmington, UT 84025"
-0.8182432432432434,0.5,"12 St Paul Dr, Chambersburg, PA 17201","1000 Norland Ave, Chambersburg, PA 17201"
-0.8177777777777778,1.9,"1400 Teche St, New Orleans, LA 70114","1419 Basin Street, New Orleans, LA 70116"
-0.8169091292430951,108.5,"100 Dutton St, Bangor, ME 04401","10 Hospital Dr, Bridgton, ME 04009"
-0.8161094158674804,3.5,"200 N Michigan Ave, Chicago, IL 60601","2400 N Ashland Avenue, Chicago, IL 60614"
-0.8160067873303167,0.6,"1805 27th St, Portsmouth, OH 45662","1202 18 th Street, Portsmouth, OH 45662"
-0.8123935349741801,1.8,"1 Shircliff Way, Jacksonville, FL 32204","1000 Water St, Jacksonville, FL 32204"
-0.810974025974026,6.3,"710 Center St, Columbus, GA 31901","7901 Veterans Parkway Columbus, GA 31909"
-0.8082565789473684,0.9,"1900 Gravier St, New Orleans, LA 70112","1419 Basin Street, New Orleans, LA 70116"
-0.8067246970472777,0.2,"564 South Ave, New Canaan, CT 06840","468 South Avenue, New Canaan CT"
-0.8058430458430459,27.7,"27 Park St, , MA 02601","275 Sandwich Street, Plymouth, MA 02360"
-0.8052151416122003,1.2,"2100 Comer Ave, Columbus, GA 31904","3702 2nd Ave, Columbus, GA 31904"
-0.8042857142857143,74.8,"42 Washington St, Norwell, MA 02061","40 Wright St, Palmer, MA 01069"
-0.804055944055944,0.8,"136 Lake St, Ephrata, PA 17522","169 Martin Ave, Ephrata, PA 17522"
-0.8037878787878788,2.7,"2861 Broad Ave, Memphis, TN 38112","2569 Douglass Ave, Memphis, TN 38114"
-0.8037380882208468,1.4,"2804 Birch St, Parkersburg, WV 26101","800 Garfield Ave, Parkersburg, WV 26101"
-0.8007612648053246,0.9,"2055 Oakdale Rd, Coralville, IA 52241","2490 Crosspark Road, Coralville, IA 52241"
-0.7999999999999999,0.2,"900 23rd St NW, Washington, DC 20037","800 21st St NW, Washington, DC 20052"
-0.798840579710145,13.0,"3201 E Houston St, San Antonio, TX 78219","323 North Loop 1604 West San Antonio, TX 78232"
-0.7986679986679988,0.4,"16251 Sylvester Rd SW, Burien, WA 98166","16045 1st Ave S, Burien, WA 98148"
-0.7984508899143045,0.8,"1305 W 18th St, Sioux Falls, SD 57105","2501 W. 22nd Street Sioux Falls, SD 57105"
-0.7975314630662679,6.9,"2451 Grant Ave, Philadelphia, PA 19114","7401 Ogontz Avenue, Philadelphia, PA 19138"
-0.7955128205128206,163.0,"2108 E Hill Ave, Valdosta, GA 31601","210 Forest Hill Drive Hamilton, GA 31811"
-0.7943965517241379,96.2,"45 W 111th St, Chicago, IL 60628","403 E 1st St, Dixon, IL 61021"
-0.7928704566635602,95.4,"4805 NE Glisan St, Portland, OR 97213","470 NE A St, Madras, OR 97741"
-0.7924731182795699,3.3,"4350 Dewey Ave, Omaha, NE 68105","8303 Dodge St, Omaha, NE 68118"
-0.7923989898989899,0.6,"124 Daniel Dr, Danville, KY 40422","1591 Hustonville Rd., Danville, KY 40422"
-0.7908496732026143,14.6,"3258 W 111th St, Chicago, IL 60655","259 E Erie St, Chicago, IL 60611"
-0.7901400679117148,13.8,"5841 S Maryland Ave, Chicago, IL 60637","5140 N California Ave, Chicago, IL 60625"
-0.7896477272727273,4.8,"2285 Sequoia Dr, Aurora, IL 60506","2853 Kirk Road  Aurora, IL 60502"
-0.7892255892255893,0.1,"1901 Redrock Dr, Gallup, NM 87301","1919 College Drive, Gallup, New Mexico 87301"
-0.788988416988417,4.2,"5504 Menaul Blvd NE, Albuquerque, NM 87110","5150 Journal Center Blvd. SE Albuquerque, NM 87109"
-0.7888975932454194,0.1,"3 Truman Parkway, Annapolis, MD 21401","1 Harry S. Truman Parkway, Annapolis, MD 21401"
-0.7884065610997343,7.0,"3000 N Fourth St, Flagstaff, AZ 86004","2446 Fort Tuthill Loop, Flagstaff, AZ 86004"
-0.7877177700348432,0.8,"1 Medical Center Dr, Morgantown, WV 26505","1200 JD Anderson Dr., Morgantown, WV 26505"
-0.7875,35.4,"111 Grossman Dr, Braintree, MA 02184","1 General St, Lawrence, MA 01841"
-0.7872722995227533,0.8,"355 S Miller Ave, Farmington, NM 87401","801 W Maple St, Farmington, NM 87401"
-0.7864285714285714,2.9,"201 E University Pkwy, Baltimore, MD 21218","22 S Greene St, Baltimore, MD 21201"
-0.7830065359477124,6.8,"7525 Tidwell Rd, Houston, TX 77016","510 W Tidwell Rd, Houston, TX, 77091"
-0.7802894779638967,13.2,"11833 Wilmington Ave, Los Angeles, CA 90059","8730 Alden Drive, Los Angeles, CA 90059"
-0.7779761904761905,0.8,"11890 Healing Way, Silver Spring, MD 20904","2121 Industrial Parkway, Silver Spring, MD 20904"
-0.7765512265512265,2.8,"186 Paradise Blvd, Athens, GA 30607","410 McKinley Dr, Athens, GA 30601"
-0.7736564996368918,47.5,"50 Hospital Dr, Hendersonville, NC 28792","1 Hospital Rd., Cherokee, NC 28719"
-0.7730407523510973,210.5,"1266 GA-515, Jasper, GA 30143","16942 GA-67, Statesboro, GA 30458"
-0.77275,0.5,"2635 Church Rd, Aurora, IL 60502","2853 Kirk Road  Aurora, IL 60502"
-0.7716758111494952,116.1,"9205 SW Barnes Rd, Portland, OR 97225","865 SW Veterans Way, Redmond, OR 97756"
-0.7705637657361795,4.2,"321 Middlefield Rd, Menlo Park, CA 94025","3250 Alpine Road, Portola Valley, CA 94028"
-0.7705471124620061,2.8,"12335 Georgia Ave, Silver Spring, MD 20906","13428 New Hampshire Ave Silver Spring, MD 20904"
-0.770045280390108,0.5,"8 Pikes Hill, Norway, ME 04268","181 Main St, Norway, ME 04268"
-0.7696852689793867,31.6,"13755 S Main St, Houston, TX 77035","136 E Hospital Dr., Angleton TX,  77515"
-0.768918918918919,1.1,"1729 Benson Ave, Evanston, IL 60201","2650 Ridge Avenue, Evanston, IL 60201"
-0.768430369787569,4.7,"7401 Jefferson Ave, Hyattsville, MD 20785","6401 America Blvd, Hyattsville, MD 20782"
-0.7676211926211927,8.5,"30 Prospect Ave, Hackensack, NJ 07601","300 Pompton Road Wayne, NJ 07470"
-0.7654441533698498,144.4,"1 Medical Park, Wheeling, WV 26003","176 Medical Center, Rainelle, WV 25962"
-0.7648412698412699,204.8,"165 Vanderbilt Ave, , NY 10304","160 Genesee St, Auburn, NY 13021"
-0.764494126563092,83.4,"275 Pine Rd, Newnan, GA 30263","2395 Thompson Rd, Dawsonville, GA 30534"
-0.7640568422490946,5.2,"800 Carter St, Rochester, NY 14621","150 Crittenden Blvd., Rochester, NY 14642"
-0.7636579371133145,195.8,"215 Lancaster Ave, Malvern, PA 19355","2128 Oakland Avenue, Indiana, PA 15701"
-0.7627659574468085,249.3,"11190 Health Park Blvd, Naples, FL 34110","400 Health Park Blvd, Saint Augustine, FL 32086"
-0.7613431013431012,25.5,"1300 Crane St, Menlo Park, CA 94025","1998 Market St, San Francisco, CA 94102"
-0.7611179670003199,54.3,"1255 GA-54, Fayetteville, GA 30214","5450 GA-20 Cartersville, GA 30121"
-0.7602182539682539,2.9,"2315 Stockton Blvd, Sacramento, CA 95817","1600 Exposition Blvd, Sacramento, CA 95815"
-0.7597772597772597,41.7,"1412 Milstead Ave, Conyers, GA 30012","410 McKinley Dr, Athens, GA 30601"
-0.7592126623376623,134.3,"214 E 23rd St, Cheyenne, WY 82001","2221 W Elm St, Rawlins, WY 82301"
-0.758751937984496,35.4,"2604 Schoenersville Rd, Bethlehem, PA 18017","2500 Bernville Rd, Reading, PA 19605"
-0.7587352302869544,118.1,"1717 S Calhoun St, Fort Wayne, IN 46802","1201 South Main Street Crown Point, IN 46307"
-0.758617153739105,0.9,"1301 W 18th St, Sioux Falls, SD 57104","2501 W. 22nd Street Sioux Falls, SD 57105"
-0.7582022311212815,0.5,"1800 NW Myhre Rd, Silverdale, WA 98383","10452 Silverdale Way N.W. Silverdale, WA 98383"
-0.7580519480519481,100.9,"2950 Cleveland Clinic Blvd, Weston, FL 33331","2776 Cleveland Ave, Fort Myers, FL 33901"
-0.7572727272727273,2.1,"13435 US-183, Austin, TX 78750","14016 N, US-183, Austin, TX 78717"
-0.7572475226649799,6.6,"510 Boston Rd, Billerica, MA 01821","1 Hospital Dr, Lowell, MA 01852"
-0.7564386256069827,111.5,"55 Fruit St, Boston, MA 02114","725 North St, Pittsfield, MA 01201"
-0.7560115638665764,71.8,"100 Hospital Rd, Prince Frederick, MD 20678","1601 Bowmans Farm Rd, Frederick, MD 21701"
-0.7557060755336618,35.7,"19801 Observation Dr, Germantown, MD 20876","1800 Orleans St, Baltimore, MD 21287"
-0.7553282182438193,63.6,"22 Bramhall St, Portland, ME 04102","420 Franklin St, Rumford, ME 04276"
-0.7550407422827573,3.3,"3401 Civic Center Blvd, Philadelphia, PA 19104","1 Citizens Bank Way, Philadelphia, PA 19148"
-0.7548627058430979,3.5,"348 Greenwood St, Worcester, MA 01607","123 Summer St, Worcester, MA 01608"
-0.7547058823529411,0.0,"3905 OK-97, Sand Springs, OK 74063","3090 State Highway 97, Sand Springs, OK 74063"
-0.7532442216652743,79.6,"725 S Wahanna Rd, Seaside, OR 97138","525 SE Washington St, Dallas, OR 97338"
-0.7521520803443328,0.7,"99 Matthew Dr, Uniontown, PA 15401","86 McClellandtown Rd, Uniontown, PA 15401"
-0.7516769073220685,0.7,"5126 Hospital Dr NE, Covington, GA 30014","8203 Hazelbrand Rd NE, Covington, GA 30014"
-0.7510850439882697,7.1,"825 S 169th St, Omaha, NE 68118","8303 Dodge St, Omaha, NE 68118"
-0.7506734006734007,325.2,"1513 W Fir St, Portales, NM 88130","801 W Maple St, Farmington, NM 87401"
-0.7503232644409116,9.9,"700 Children's Dr, Columbus, OH 43205","4760 Sawmill Rd, Columbus OH 43235"
-0.7502764127764129,52.0,"1900 Washington St, Grafton, WI 53024","10400 75th St., Kenosha, WI 53142"
-0.7492737835875091,0.2,"1945 NJ-33, Neptune City, NJ 07753","2040 Route 33 Neptune City, NJ 07753"
-0.7490970499035016,0.8,"241 N Figueroa St, Los Angeles, CA 90012","1700 Stadium Way, Los Angeles, CA 90012"
-0.7486166007905138,11.1,"15740 S Outer Forty Rd, Chesterfield, MO 63017","12409 St. Charles Rock Rd, Bridgeton, MO 63044"
-0.7483787593984963,23.4,"1400 Cambridge St, Cambridge, MA 02138","1 General St, Lawrence, MA 01841"
-0.7475708502024291,299.1,"1940 N Monroe St, Tallahassee, FL 32303","1410 Sports Blvd, Cape Coral, FL 33991"
-0.7474358974358973,48.2,"190 Blue Devil Ln, Gainesboro, TN 38562","1503 S Main St, Crossville, TN 38555"
-0.7471713471713471,4.7,"401 N Ewing St, Lancaster, OH 43130","2384 N Memorial Dr, Lancaster, OH 43130"
-0.7467082467082468,0.6,"200 Ocean 36th St, Marathon, FL 33050","2805 Overseas HWY Marathon, FL 33050"
-0.7464214046822744,40.5,"7201 N University Dr, Tamarac, FL 33321","7305 N Military Trl, West Palm Beach, FL 33410"
-0.74618312963334,82.8,"3318 N Northhills Blvd, Fayetteville, AR 72703","358 East Valley Street Yellville, AR 72687"
-0.7461538461538462,4.0,"5205 Melrose Ave, Los Angeles, CA 90038","8730 Alden Drive, Los Angeles, CA 90059"
-0.7455706521739132,1.1,"1631 Elysian Fields Ave, New Orleans, LA 70117","1419 Basin Street, New Orleans, LA 70116"
-0.7449199922884132,13.9,"330 W Maple Ave, Monrovia, CA 91016","1101 W. McKinley Ave, Pomona, CA 91768"
-0.7429666119321291,41.9,"580 Court St, Keene, NH 03431","1059 Canal St, Manchester, NH 03101"
-0.7429361179361179,118.9,"1001 Providence Dr, Newberg, OR 97132","1501 NE Medical Center Drive, Bend, OR 97701"
-0.7427751460009525,80.9,"745 Poplar Rd, Newnan, GA 30265","2395 Thompson Rd, Dawsonville, GA 30534"
-0.7423893065998329,14.0,"2094 Pitkin Ave, , NY 11207","2210 Bartow Avenue, Bronx, NY 10475"
-0.7419799498746869,29.7,"193 NY-59, Nanuet, NY 10954","1500 NY-9D, Wappingers Falls, NY 12590"
-0.74160724896019,26.5,"5 Garrett Ave, La Plata, MD 20646","10251 Central Ave, Largo, MD 20774"
-0.741,183.5,"1127 Bruce B Downs Blvd, Wesley Chapel, FL 33544","1425 South Congress Avenue, Delray Beach, FL 33445"
-0.7408708560118753,7.9,"2110 Sunset Blvd Suite M, Los Angeles, CA 90026","2040 Camfield Avenue, Los Angeles, Ca 90040"
-0.7398780487804878,39.4,"15910 Chieftain Ave, Rockville, MD 20855","11760 Baltimore Ave, Beltsville, MD 20705"
-0.7393406593406594,2.6,"300 Pasteur Dr, Palo Alto, CA 94304","3250 Alpine Road, Portola Valley, CA 94028"
-0.7389047619047618,116.8,"12500 Willowbrook Rd, Cumberland, MD 21502","1800 Orleans St, Baltimore, MD 21287"
-0.7388278388278389,87.6,"9449 Friars Rd, San Diego, CA 92108","4300 Rose Dr, Yorba Linda, CA 92886"
-0.7384254443751012,5.7,"506 Malcolm X Blvd, New York, NY 10037","225 W 23rd St, New York, NY 10011"
-0.7383040935672515,2.5,"750 S Park Ave, Pomona, CA 91766","1101 W. McKinley Ave, Pomona, CA 91768"
-0.7378147526414537,63.8,"1125 Madison St, Jefferson City, MO 65101","1717 Madison Ave, Washington, MO 63090"
-0.737718498252014,24.6,"16520 S Westland Dr, Gaithersburg, MD 20877","10251 Central Ave, Largo, MD 20774"
-0.7376518218623482,5.9,"121 Dekalb Ave, , NY 11201","1143 Lexington Ave, New York, NY 10021"
-0.7376232917409388,171.3,"20 Hartford St, Houlton, ME 04730","420 Franklin St, Rumford, ME 04276"
-0.7371040723981899,52.0,"20 S Plum St, Vermillion, SD 57069","2100 S Marion Rd, Sioux Falls, SD 57106"
-0.736842105263158,276.0,"501 N Glendale Ave, Glendale, CA 91206","550 South Green Valley Road, Watsonville, CA 95076"
-0.7368181818181818,190.6,"100 N Portland Ave, , NY 11205","1500 N. James St., Rome, NY 13440"
-0.7366452991452991,40.4,"2900 Foxfield Dr, St. Charles, IL 60174","900 N 2nd St, Rochelle, IL 61068"
-0.7365266106442577,14.8,"6150 E Broad St, Columbus, OH 43213","4760 Sawmill Rd, Columbus OH 43235"
-0.7365266106442577,37.3,"1210 Provident Dr, Warsaw, IN 46580","700 Broadway, Fort Wayne, IN 46802"
-0.7364182364182364,2.2,"5755 Cedar Ln, Columbia, MD 21044","6340 Woodside Ct, Columbia, MD, 21046"
-0.7360269360269361,225.0,"35 Clayton Rd, Arden, NC 28704","111 Sunnybrook Rd, Raleigh, NC 27610"
-0.7358220211161388,0.1,"24 Hospital Ave, Danbury, CT 06810","95 Loucust Ave, Danbury CT"
-0.7354464285714286,89.4,"3635 Market St, Hoover, AL 35226","320 Main St, Roanoke, AL 36274"
-0.7349769585253456,148.8,"251 N 4th St, Oakland, MD 21550","22 S Greene St, Baltimore, MD 21201"
-0.7347347176136557,3.0,"800 E Carpenter St, Springfield, IL 62769","2950 South Sixth Street, Springfield, IL 62703"
-0.7343603766367993,2.9,"120 Craig Rd, Freehold Township, NJ 07728","315 W. Main Street Freehold, NJ 07728"
-0.7342555994729908,145.7,"643 5th St, Fort Sumner, NM 88119","356 9th St, Cimarron, NM 87714"
-0.7341269841269841,1.6,"800 Clematis St, West Palm Beach, FL 33401","2606 S Dixie Hwy., West Palm Beach, FL 33401"
-0.7335880398671096,9.6,"101 E Olney Ave C5, Philadelphia, PA 19120","1 Citizens Bank Way, Philadelphia, PA 19148"
-0.732404181184669,1.6,"2905 3rd Ave SE, Aberdeen, SD 57401","305 South State Street Aberdeen, SD 57401"
-0.7323436797121007,1.3,"333 Borthwick Ave, Portsmouth, NH 03801","599 Lafayette Rd, Portsmouth, NH 03801"
-0.7319613135402608,103.7,"1500 Division St, Oregon City, OR 97045","13000 SW Century Drive, Bend, OR 97702"
-0.7318166219504587,4.6,"1500 Forest Glen Rd, Silver Spring, MD 20910","13428 New Hampshire Ave Silver Spring, MD 20904"
-0.7316299929303641,3.6,"50 N Medical Dr, Salt Lake City, UT 84132","1280 E Stringham Ave, Salt Lake City, UT 84106"
-0.7308287687544652,62.0,"1037 NY-109, Farmingdale, NY 11735","1500 NY-9D, Wappingers Falls, NY 12590"
-0.7307954545454546,22.0,"7495 State St, Midvale, UT 84047","777 N Main St Tooele, UT 84074"
-0.7307797270955166,20.2,"18101 Preston Rd 201, Dallas, TX 75252","3201 W. Saner Ave., Dallas, TX 75233"
-0.7304504504504504,22.5,"1080 Stelton Rd, Piscataway, NJ 08854","2100 Wescott Dr, Flemington, NJ 08822"
-0.7300000000000001,33.0,"2125 NJ-88, Brick Township, NJ 08724","2421 US-1, North Brunswick Township, NJ 08902"
-0.7291412291412293,7.9,"51 N 39th St, Philadelphia, PA 19104","7401 Ogontz Avenue, Philadelphia, PA 19138"
-0.7283500717360115,31.1,"327 Medical Park Dr, Bridgeport, WV 26330","207 S Price St, Kingwood, WV 26537"
-0.72819205883722,7.7,"10050 Roosevelt Blvd, Philadelphia, PA 19116","7401 Ogontz Avenue, Philadelphia, PA 19138"
-0.7281792281792283,7.2,"3401 SE 10th Ave, Amarillo, TX 79104","7304 SW 34th, Amarillo, TX"
-0.7272676205942131,2.5,"910 Old Camp Rd 130, The Villages, FL 32162","703 N Buena Vista Blvd, The Villages, FL 32162"
-0.7268705952916479,85.6,"468 Cadieux Rd, Grosse Pointe, MI 48230","804 Service Rd, East Lansing, MI 48824"
-0.7267284816373175,2.7,"3330 Siskey Pkwy, Matthews, NC 28105","630 Matthews Township Pkwy, Matthews, NC 28105"
-0.7263427109974425,12.8,"1 College Dr, Toms River, NJ 08753","701 U.S. 9, Forked River, NJ 08731"
-0.7257044419835118,21.4,"520 S Maple Ave, Oak Park, IL 60304","777 Park Ave. West, Highland Park, IL 60035"
-0.7254960317460318,10.3,"6959 Forest Preserve Dr, Chicago, IL 60634","259 E Erie St, Chicago, IL 60611"
-0.7245234708392604,259.1,"201 N Mayfair Rd, Wauwatosa, WI 53226","13380 W Trepania Rd, Hayward, WI 54843"
-0.7244152046783626,18.7,"30809 1st Ave S, Federal Way, WA 98003","720 8th Ave S, Seattle, WA 98104"
-0.7243083003952568,8.3,"1218 Trotwood Ave Bldg C, Columbia, TN 38401","2478 Nashville Hwy Suite A, Columbia, TN 38401"
-0.7240259740259741,5.3,"3563 Far W Blvd, Austin, TX 78731","12319 N Mopac Expy, Austin, TX 78758"
-0.7239626723497691,0.5,"1600 E 32nd St, Silver City, NM 88061","2610 N. Silver, Silver City, New Mexico 88061"
-0.7236323279801541,49.3,"50 Worcester Rd, Framingham, MA 01702","40 Wright St, Palmer, MA 01069"
-0.7236165577342049,5.8,"8201 Golf Course Rd NW, Albuquerque, NM 87120","5150 Journal Center Blvd. SE Albuquerque, NM 87109"
-0.7233733733733733,37.5,"901 E Fifth St, Washington, MO 63090","6900 Chippewa St, St. Louis, MO 63109"
-0.7232804232804232,2.0,"13155 Noel Rd 2000, Dallas, TX 75240","5917 Belt Line Rd, Dallas TX"
-0.7232563115104836,10.1,"4122 Market St, Philadelphia, PA 19104","7131 Frankford Ave Philadelphia, PA 19135"
-0.7230769230769231,148.1,"1801 E 51st St Bldg H, Austin, TX 78723","5616 Lawndale St., Ste A108 Houston, TX 77023"
-0.7226347226347226,8.1,"111 S 11th St, Philadelphia, PA 19107","7401 Ogontz Avenue, Philadelphia, PA 19138"
-0.7222222222222222,41.8,"1 Cooper Plaza, Camden, NJ 08103","215 Applegarth Road Monroe, NJ 08831"
-0.7204083115373437,0.6,"95 Leonard Ave 203, Washington, PA 15301","37 Highland Ave, Washington, PA 15301"
-0.7199001339666302,1.8,"55 Lake Ave N., Worcester, MA 01604","123 Summer St, Worcester, MA 01608"
-0.7198912198912198,7.7,", Fort Wayne, IN 46845","2200 Randallia Dr, Fort Wayne, IN 46805"
-0.7196400091136933,21.2,"550 Peachtree St NE, Atlanta, GA 30308",4350 North Point Parkway Alpharetta GA 30022
-0.7190651750148317,11.2,"235 S Gary Ave, Bloomingdale, IL 60108","137 W North Ave, Northlake, IL 60164"
-0.7189959798655451,1.1,", Stony Brook, NY 11790","101 Nicolls Road, Stony Brook, NY 11794"
-0.7175802139037434,225.7,"2747 4th St, Brunswick, GA 31520","727 54th Street Columbus, GA 31904"
-0.7168394471026049,16.6,"229 Andover St, Peabody, MA 01960","1290 Tremont Street ,Roxbury, MA 02120"
-0.7167000381388253,21.0,"34515 9th Ave S, Federal Way, WA 98003","720 8th Ave S, Seattle, WA 98104"
-0.7166537966537966,37.6,"10350 Haligus Rd, Huntley, IL 60142","2650 Ridge Avenue, Evanston, IL 60201"
-0.7163041579315164,0.2,"1016 Roosevelt Ave, Grants, NM 87020","700 E. Roosevelt, Suite 100, Grants, New Mexico 87020"
-0.7162162162162162,373.3,"1306 W Stevens St, Carlsbad, NM 88220","801 W Maple St, Farmington, NM 87401"
-0.715619610741562,6.9,"2211 Lomas Blvd NE, Albuquerque, NM 87106","13701 Encantado Rd. NE Albuquerque, NM 87123"
-0.7153371320037986,27.9,"200 Memorial Ave, Westminster, MD 21157","1800 Orleans St, Baltimore, MD 21287"
-0.7151424963924965,5.7,"5521 Lincoln Hwy 1a, Crown Point, IN 46307","1201 South Main Street Crown Point, IN 46307"
-0.7142235159476539,103.8,"501 Santiago Park Ln, Kingsville, TX 78363","1000 Sports Park Blvd, Brownsville, TX 78526"
-0.7139802191927291,5.9,"809 University Blvd E, Tuscaloosa, AL 35401","9070 Highway 69 South, Tuscaloosa, AL 35405"
-0.7136199528440907,73.5,"100 Sentara Cir, Williamsburg, VA 23188","4600 Spotsylvania Pkwy, Fredericksburg, VA 22408"
-0.7131180297978096,4.0,"1 University Heights, Asheville, NC 28804","711 New Leicester Hwy, Asheville, NC 28806"
-0.7125220458553793,26.5,"100 Medical Plaza, Lake St Louis, MO 63367","3802 S Lindbergh Blvd, St. Louis, MO 63127"
-0.7123642439431913,8.4,"3400 Spruce St, Philadelphia, PA 19103","7401 Ogontz Avenue, Philadelphia, PA 19138"
-0.712037037037037,2.0,"2400 Unser Blvd SE, Rio Rancho, NM 87124","1721 Rio Rancho Blvd. SE Rio Rancho, NM 87124"
-0.7118233618233619,26.5,"601 Concord Ave, Cambridge, MA 02138","140 Lincoln Avenue, Haverhill, MA 01830"
-0.711417748917749,3.7,"22 Jefferson St, Hartford, CT 06106","1000 Asylum Street, Hartford, CT"
-0.711417748917749,101.4,"400 E Burdick Expy, Minot, ND 58701","300 N 7th St, Bismarck, ND 58501"
-0.7111207505944348,2.3,"1481 W 10th St, Indianapolis, IN 46202","893 Delaware St, Indianapolis, IN 46225"
-0.7106357694592988,63.8,"2302 College Ave, Conway, AR 72034","309 S Edline, Altheimer, AR 72004"
-0.7106357694592988,113.3,"1926 Oak St, Unionville, MO 63565","601 S US-169, Smithville, MO 64089"
-0.7103918434563595,1.0,"535 Centerville Rd, Warwick, RI 02886","400 East Ave, Warwick, RI 02886"
-0.7092592592592593,11.2,"97 Progress Blvd, Shippensburg, PA 17257","1000 Norland Ave, Chambersburg, PA 17201"
-0.709090909090909,43.9,"230 E 10th St, Anniston, AL 36207","320 Main St, Roanoke, AL 36274"
-0.7086999022482893,183.5,"5450 Fort St, Trenton, MI 48183","400 Hobart St, Cadillac, MI 49601"
-0.7080597221262184,71.3,"2070 IL-50 500, Bourbonnais, IL 60914","450 W Hwy 22, Barrington, IL 60010"
-0.7080597221262184,199.3,"1001 W Memorial Dr, Artesia, NM 88210","215 S Silver Ave, Deming, NM 88030"
-0.7080139372822299,93.5,"7370 Baker St, Pittsburgh, PA 15206","271 Railroad Street Philipsburg, PA 16866"
-0.7078521785618818,27.7,"380 N Oxford Valley Rd, Langhorne, PA 19047","250 King of Prussia Rd, Radnor, PA 19087"
-0.7076315789473684,22.5,"2001 Medical Pkwy, Annapolis, MD 21401","6401 America Blvd, Hyattsville, MD 20782"
-0.707548449612403,101.0,"1401 1st St W, Webster, SD 57274","604 1st St NE, Wessington Springs, SD 57382"
-0.7074686638581161,49.3,"31 Union St, Vernon, CT 06066","130 Division St, Derby, CT"
-0.7072733918128655,63.3,"345 Main St, Tewksbury, MA 01876","40 Wright St, Palmer, MA 01069"
-0.706215905828309,107.3,"480 W Lowder St, Macclenny, FL 32063","1360 Saxon Boulevard, Orange City, FL 32763"
-0.7061557605035866,273.2,"310 S 2nd St, Tucumcari, NM 88401","801 W Maple St, Farmington, NM 87401"
-0.7061557605035866,11.1,"636 Raymond Dr, Naperville, IL 60563","300 Randall Road Geneva, IL 60134"
-0.7056334622823984,22.0,"420 N West End St Suite B, Springdale, AR 72764","500 S Mt Olive St #200, Siloam Springs, AR 72761"
-0.7055976430976432,177.2,"255 Lafayette Ave, Suffern, NY 10901","160 Genesee St, Auburn, NY 13021"
-0.7054838880925837,145.8,"1111 Crater Lake Ave, Medford, OR 97504","435 E Alder Street, Alsea, OR 97324"
-0.7053884711779449,15.8,"451 Clarkson Ave, , NY 11203","2210 Bartow Avenue, Bronx, NY 10475"
-0.7050537538342416,13.0,"17512 Dona Michelle Dr 5, Tampa, FL 33647","4201 N Dale Mabry Hwy., Tampa, FL 33607"
-0.7048229548229549,38.1,"54 Seven Lakes Dr, Sloatsburg, NY 10974","3 Delaware Drive Lake Success, NY 11042"
-0.7046783625730993,0.8,", Memphis, TN 38104","2569 Douglass Ave, Memphis, TN 38114"
-0.7045478279030911,127.1,"4700 Highlands Way, Irondale, AL 35210","1350 Highway 231, Troy, AL 36081"
-0.7045028142589119,304.6,"2518 Mission College Blvd 101, Santa Clara, CA 95054","10250 Santa Monica Blvd #1450, Los Angeles, CA 90067"
-0.7044642857142858,100.5,"75 Park St, Elizabethtown, NY 12932","1001 West St, Carthage, NY 13619"
-0.7044642857142858,33.3,"789 Central Ave, Dover, NH 03820","1059 Canal St, Manchester, NH 03101"
-0.7044171444171444,251.9,"810 12th St, Hood River, OR 97031","1108 SW 4th Street, Ontario, OR 97914"
-0.70379062362758,6.5,"7018 S Utica Ave, Tulsa, OK 74136","315 South Utica, Tulsa, Ok 74104"
-0.7037837837837838,1.0,"4821 US-19, New Port Richey, FL 34652","5355 School Rd. Port Richey, FL 34652"
-0.7036945812807881,125.8,"302 College St, Lafayette, TN 37083","266 Joule St, Alcoa, TN 37701"
-0.7036945812807881,77.9,"4 Jersey St, Boston, MA 02215","230 Maple Street, Holyoke, MA 01040"
-0.7032678806320227,31.1,"720 Boston Turnpike, Shrewsbury, MA 01545","1290 Tremont Street ,Roxbury, MA 02120"
-0.7031529516994633,297.3,"930 W St Rd, Feasterville-Trevose, PA 19053","150 West 3rd St., Erie, PA 16505"
-0.702986633249791,264.4,"3807 McNutt Rd, Sunland Park, NM 88063","4801 Beckner Rd, Santa Fe, NM 87507"
-0.7017104542966611,9.2,"10800 Knights Rd, Philadelphia, PA 19114","7401 Ogontz Avenue, Philadelphia, PA 19138"
-0.7007575757575758,79.1,"3580 W 9000 S, West Jordan, UT 84088","935 N 1000 W, Tremonton, UT 84337"
-0.7006468190678716,106.6,"3351 McMullen Booth Rd, Clearwater, FL 33761","1410 Sports Blvd, Cape Coral, FL 33991"
-0.7006105006105005,80.4,"800 Professional Blvd, Dalton, GA 30720","1000 Rowland St, Clarkston GA 30021"
-0.7004138950480413,9.3,"1800 Unser Blvd NW, Albuquerque, NM 87120","5150 Journal Center Blvd. SE Albuquerque, NM 87109"
-0.7001984126984127,237.2,"580 W Germantown Pike, Plymouth Meeting, PA 19462","4220 William Penn Highway, Monroeville, PA 15146"
-0.7000921375921377,53.9,"8490 Hwy 72 W, Madison, AL 35758","1101 Hwy 72 EAST, Tuscumbia, AL 35674"
-0.6999405822935234,104.9,"303 S Main St, Bluffton, IN 46714","703 N Main St Kouts, Indiana 46347"
-0.6995801469485681,101.0,"1105 E Kennedy Blvd, Tampa, FL 33602","1205 S Woodland Blvd, DeLand, FL 32720"
-0.6993874857443073,170.7,"820 Illinois Rte 59, Bartlett, IL 60103","2950 South Sixth Street, Springfield, IL 62703"
-0.6991830065359478,241.4,"102 Mason Farm Rd, Chapel Hill, NC 27514","1 Hospital Rd., Cherokee, NC 28719"
-0.6987732528909,198.3,"2151 W Spring St, Monroe, GA 30655","7221 Sallie Mood Dr, Savannah, GA 31406"
-0.6987654320987655,8.6,"1 Plainsboro Rd, , NJ 08536","215 Applegarth Road Monroe, NJ 08831"
-0.6986127784447111,73.8,"2555 Judge Fran Jamieson Way, Melbourne, FL 32940","1245 West Granada Boulevard, Ormond Beach, FL 32174"
-0.698571926158133,37.6,"65 James St, Edison, NJ 08820","500 Route 57 Washington, NJ 07882"
-0.6984901648059543,0.7,"2920 Telegraph Ave, Berkeley, CA 94705","2500 Milvia St Berkeley, CA 94704"
-0.6984126984126985,46.0,"106 Bow St, Elkton, MD 21921","1800 Orleans St, Baltimore, MD 21287"
-0.6975524475524475,58.3,"1968 Peachtree Rd NW, Atlanta, GA 30309","1199 Prince Ave, Athens, GA 30606"
-0.6972350230414747,80.5,"745 E 8th St, Winner, SD 57580","513 3rd St SW, Wagner, SD 57380"
-0.696727373332695,272.4,"900 N Flamingo Rd, Pembroke Pines, FL 33028","400 Health Park Blvd, Saint Augustine, FL 32086"
-0.6967067067067066,3.8,"1720 S University Dr, Fargo, ND 58103","2101 Elm Street N.   Fargo, ND 58102"
-0.6962433862433862,253.0,"801 S 70th St, West Allis, WI 53214","1700 W Stout St, Rice Lake, WI 54868"
-0.6960317460317461,308.9,"1801 N Temple Ave, Starke, FL 32091","1350 NW 50 ST, Miami, FL 33142"
-0.6958257513096223,86.3,"2360 Hospital Dr 1, Aliquippa, PA 15001","621 S Main St, DuBois, PA 15801"
-0.6957125981516225,110.3,"3021 Griffin Ave, Enumclaw, WA 98022","2901 Squalicum Pkwy, Bellingham, WA 98225"
-0.6957125981516225,8.8,"3730 W 4700 S, West Valley City, UT 84118","389 S 900 E Salt Lake City, UT 84102"
-0.6956654456654457,24.5,"1050 E Philadelphia Ave, Gilbertsville, PA 19525","1440 East Butler Pike, Ambler, PA 19002"
-0.6954430255161045,186.9,"1216 Cameo St, Clovis, NM 88101","2669 N Scenic Dr, Alamogordo, NM 88310"
-0.6953140096618359,59.5,"10256 Old Green Bay Rd, Pleasant Prairie, WI 53158","3200 Pleasant Valley Road, West Bend, WI 53095"
-0.6947876447876448,675.1,"200 W Arbor Dr, San Diego, CA 92103","2700 Dolbeer Street, Eureka, CA 95501"
-0.6946696567189926,10.3,"9 Mule Rd, Toms River, NJ 08755","701 U.S. 9, Forked River, NJ 08731"
-0.6944444444444443,513.6,"7643 Painter Ave, Whittier, CA 90602","351 Hartnell Ave., Redding, CA 96001"
-0.6942151162790697,2.7,"777 Bannock St, Denver, CO 80204","1400 Jackson Street, Denver, Colorado 80206"
-0.6937224502203981,25.0,"801 Viney Grove Rd, Prairie Grove, AR 72753","601 SW Regional Airport Blvd, Bentonville, AR 72713"
-0.6936494461961354,229.1,"211 FM 544, Murphy, TX 75094","1410 Fry Rd., Houston, TX 77084"
-0.6935669685030299,61.9,"364 Pritham Ave, Greenville, ME 04442","149 North St, Waterville, ME 04901"
-0.693475239558189,59.6,"28050 Grand River Ave, Farmington Hills, MI 48336","3550 Pine Grove Ave., Port Huron, MI 48060"
-0.6931920006516781,0.1,"400 Paramus Rd, Paramus, NJ 07652","Paramus Campus – Lots B & C 400 Paramus Road Paramus, NJ 07652"
-0.6931667403803626,115.4,"52 Tech Dr, Tifton, GA 31794","727 54th Street Columbus, GA 31904"
-0.6931481481481482,257.2,"3201 S 16th St 1000, Milwaukee, WI 53215","1700 W Stout St, Rice Lake, WI 54868"
-0.6931481481481482,90.8,"2442 Bloomingdale Ave, Valrico, FL 33596","1200 Deltona Blvd, Deltona, FL 32725"
-0.6931476931476932,106.5,"334 12th Ave SE, Norman, OK 73071","433 Fairview Ave Ponca City, OK 74601"
-0.6930736404420615,313.4,"9311 SW State Rd 200, Ocala, FL 34481","3200 W De Soto St, Pensacola, FL 32505"
-0.6930571686669248,31.6,"8600 Old Georgetown Rd, Bethesda, MD 20814","1601 Bowmans Farm Rd, Frederick, MD 21701"
-0.6928571428571427,163.0,"2500 Metrohealth Dr, Cleveland, OH 44109","55 Centennial Blvd, Chillicothe OH 45601"
-0.6924963924963925,83.6,"600 Highland Ave, Madison, WI 53792","10400 75th St., Kenosha, WI 53142"
-0.6922799422799423,171.9,"600 Mary St, Evansville, IN 47710","5165 McCarty Ln, Lafayette, IN 47905"
-0.6922337722337722,288.3,"224 SE 24th St, Gainesville, FL 32641","1475 West 49th Place, Hialeah, FL 33012"
-0.6920968587635254,16.0,"21 Romance Hill Rd, Belfair, WA 98528","9621 Ridgetop Blvd NW Silverdale, WA 98383"
-0.6915957605612778,5.2,"1 Bay St, Montclair, NJ 07042","617 Broad Street Newark, NJ 07102"
-0.6912657806618,12.3,"2400 Wellesley Ave NE, Albuquerque, NM 87107","7440 Jim McDowell Rd NW, Albuquerque, NM, 87114"
-0.6912393162393161,192.8,"1100 E 3rd St, Chattanooga, TN 37403","1501 W. Elk Ave, Elizabethton, TN 37643"
-0.6910629514963881,58.3,"214 Washington St, Claremont, NH 03743","240 S Main St, Wolfeboro, NH 03894"
-0.6910602540113366,49.0,"1683 E Florence Blvd, Casa Grande, AZ 85122","13400 E Shea Blvd, Scottsdale, AZ 85259"
-0.6909917134456028,37.0,"9901 Medical Center Dr, Rockville, MD 20850","11 Industrial Park Drive, Waldorf, MD 20602"
-0.6906928480204342,62.5,"70 Main St, Norwich, CT 06360","2979 Main Street, Bridgeport, CT"
-0.6906796906796907,3.2,"100 Twin River Rd, Lincoln, RI 02865","600 Rhode Island Ave, Providence, RI 02908"
-0.6905723905723905,89.9,"111 Maltese Dr, Middletown, NY 10940","1 Atwell Road, Cooperstown, NY"
-0.690446127946128,14.2,"2520 Cherry Ave, Bremerton, WA 98310","720 8th Ave S, Seattle, WA 98104"
-0.6903371320037986,4.4,"1401 Jefferson Hwy, Jefferson, LA 70121","1419 Basin Street, New Orleans, LA 70116"
-0.6903371320037986,44.7,"214 Center Grove Rd, Randolph, NJ 07869","225 N Clinton Ave # 1, Trenton, NJ 08609"
-0.6902162014230978,120.5,"201 Morningside Dr, Sandersville, GA 31082","210 Forest Hill Drive Hamilton, GA 31811"
-0.690079667768455,53.2,"1455 Battersby Ave, Enumclaw, WA 98022","3927 Rucker Avenue Everett, WA 98201"
-0.689882697947214,207.6,"809 Jackson St, Burke, SD 57523","2116 Jackson Boulevard, Rapid City, SD 57702"
-0.6898412698412698,4.8,"26 S Main St, Centerville, UT 84014","165 N University Ave, Farmington, UT 84025"
-0.6897435897435896,51.1,"1140 NJ-72, Stafford Township, NJ 08050","2421 US-1, North Brunswick Township, NJ 08902"
-0.6896974863726782,325.8,"215 E Hawaii Ave, Nampa, ID 83686","520 N 3rd Ave, Sandpoint, ID 83864"
-0.6896135265700484,7.7,"5950 University Ave, West Des Moines, IA 50266","2103 Ingersoll Ave, Des Moines, IA 50312"
-0.6893217893217892,463.4,"8135 Calumet Ave, Munster, IN 46321","2861 Broad Ave, Memphis, IN 38112"
-0.6891133557800225,71.7,"335 E Ave K 6 B, Lancaster, CA 93535","1081 N China Lake Blvd, Ridgecrest, CA 93555"
-0.6890977443609022,373.2,"440 N Hiawatha Dr, Canton, SD 57013","1440 N Main Street Spearfish, SD 57783"
-0.688863287250384,141.1,"701 3rd Ave S, Clear Lake, SD 57226","513 3rd St SW, Wagner, SD 57380"
-0.6888211991078266,68.7,"135 Maple St, Decatur, GA 30030","1514 Vernon Rd, Lagrange, GA 30240"
-0.6888047138047138,487.4,"701 S Stemmons Fwy, Lewisville, TX 75067","1000 Sports Park Blvd, Brownsville, TX 78526"
-0.6887289463376419,39.8,"2507 N Richmond Rd, McHenry, IL 60050","5140 N California Ave, Chicago, IL 60625"
-0.6884259259259259,50.5,"525 William F McClellan Hwy, Boston, MA 02128","450 William S Canning Blvd. Fall River, MA 02721"
-0.6881836945304437,116.8,"10150 SE 32nd Ave, Milwaukie, OR 97222","815 SW Bond Street, Bend, OR 97702"
-0.687966537966538,4.8,"755 N Roop St 101, Carson City, NV 89701","900 E. Long St. Carson City, NV 89706"
-0.6878787878787879,72.7,"520 Montgomery Hwy, Vestavia Hills, AL 35216","350 County Road 4 West, Prattville, AL 36067"
-0.6878443848377103,3.8,"7 Blanchard Cir, Wheaton, IL 60189","4201 Winfield Road, Warrenville, IL 60555"
-0.687825311942959,0.1,"516 Nizhoni Blvd, Gallup, NM 87301","1919 College Drive, Gallup, New Mexico 87301"
-0.6877145308924485,5.3,"300 Central Ave, East Orange, NJ 07018","1000 Morris Ave, Union, NJ 07083"
-0.6875252525252525,23.9,"116 Garden State Pkwy, Holmdel, NJ 07733","617 Broad Street Newark, NJ 07102"
-0.6874736632876167,38.2,"18101 Prince Philip Dr, Olney, MD 20832","11 Industrial Park Drive, Waldorf, MD 20602"
-0.6872951739618407,185.2,"270 E Court Ave, Selmer, TN 38375","701 County Service Drive Cookeville, TN 38501-3338"
-0.6872256872256872,177.3,"1500 N Oakland Ave, Bolivar, MO 65613","10923 Olive Blvd, Creve Coeur, MO 63141"
-0.6871243914722176,60.4,"1700 Alber St 100, Wabash, IN 46992","1701 S Creasy Ln, Lafayette, IN 47905"
-0.6869952659426343,192.3,"55 Pacific Ave, SF, CA 94111","1035 Placer Street, Redding, CA. 96001"
-0.6869095816464238,42.1,"360 Station Dr, Crystal Lake, IL 60014","635 N. Fairbanks Ct, Chicago, IL 60611"
-0.686904761904762,0.4,"1850 Gateway Dr, Sycamore, IL 60178","2496 DeKalb Ave.  Sycamore, IL 60178"
-0.6863067926225822,34.5,"17960 S Halsted St, Homewood, IL 60430","9600 Gross Point Road, Skokie, IL 60076"
-0.6860877684407095,13.4,"58 Bedford St, Lexington, MA 02421","500 Lynnfield Street Lynn, MA 01904"
-0.6857231906320265,25.2,"2500 Allen Creek Rd, Gainesville, GA 30507","2570 Riverside Parkway Lawrenceville, GA 30046"
-0.6856957207834401,7.4,"350 S Waukegan Rd, Deerfield, IL 60015","1775 Dempster Street, Park Ridge, IL 60068"
-0.6854367854367854,216.5,"2201 Mt Zion Pkwy, Morrow, GA 30260","7221 Sallie Mood Dr, Savannah, GA 31406"
-0.685428849902534,2.5,", Melrose Park, IL 60160","137 W North Ave, Northlake, IL 60164"
-0.6852941176470587,114.7,"660 Firetower Rd, Dublin, GA 31021","210 Forest Hill Drive Hamilton, GA 31811"
-0.6852826510721247,15.8,"33 Kilmer Rd, Edison, NJ 08817","215 Applegarth Road Monroe, NJ 08831"
-0.6845234708392604,58.3,"800 Spruce St, Philadelphia, PA 19107","850 Greenfield Rd, Lancaster, PA 17601"
-0.6844834307992204,93.1,"1170 N Solano Dr, Las Cruces, NM 88001","2610 N. Silver, Silver City, New Mexico 88061"
-0.6840601503759399,19.0,"110 E Ridgewood Ave, Paramus, NJ 07652","399 Route 10 East Hanover, NJ 07936"
-0.6840601503759399,18.9,"230 E Ridgewood Ave, Paramus, NJ 07652","399 Route 10 East Hanover, NJ 07936"
-0.6840541495896745,236.4,"4412 Kell W Blvd, Wichita Falls, TX 76309","600 N Bell Blvd, Cedar Park, TX 78613"
-0.684041394335512,100.5,"127 Anderson St STE 101, Pittsburgh, PA 15212","761 Johnsonburg Rd Suite 160, St Marys, PA 15857"
-0.6837320574162679,235.3,"7943 Moffett Rd, Semmes, AL 36575","320 Main St, Roanoke, AL 36274"
-0.6829409578770193,680.8,"5115 El Paso Dr, El Paso, TX 79905","136 E Hospital Dr., Angleton TX,  77515"
-0.682785841609371,166.2,"1933 Edwin Dr, Chesapeake, VA 23322","8008 Westpark Dr, McLean, VA 22102"
-0.6827485380116959,133.7,"1500 Idalia Rd B, Bernalillo, NM 87004","801 W Maple St, Farmington, NM 87401"
-0.6826617826617826,110.0,"1220 Iyannough Rd, Barnstable, MA 02601","40 Wright St, Palmer, MA 01069"
-0.6826516897081413,257.3,"1 Ocean Pkwy, Wantagh, NY 11793","1001 West St, Carthage, NY 13619"
-0.6825396825396824,2.7,"3500 Knoxville Zoo Dr, Knoxville, TN 37914","140 Dameron Avenue   Knoxville, TN 37917-6413"
-0.6818575761952911,110.1,"211 St Francis Dr, Cape Girardeau, MO 63703","12409 St. Charles Rock Rd, Bridgeton, MO 63044"
-0.6812636165577342,311.8,"200 E Chisum St, Roswell, NM 88203","801 W Maple St, Farmington, NM 87401"
-0.6812409812409812,1.3,"2 Renshaw Rd, Darien, CT 06820","80 High School Ln, Darien, CT 06820"
-0.6812159058283088,5.1,"1101 Medical Center Blvd, Marrero, LA 70072","1419 Basin Street, New Orleans, LA 70116"
-0.6811147186147185,71.6,"53 Academy Dr, Westampton, NJ 08060","300 Pompton Road Wayne, NJ 07470"
-0.6810397353875614,40.7,"7600 River Rd, North Bergen, NJ 07047","2040 Route 33 Neptune City, NJ 07753"
-0.6805712669683258,0.0,"S Oakes St & E Beauregard Ave, San Angelo, TX 76903","101-199 S Oakes St San Angelo, TX 76903"
-0.6805555555555555,100.0,"1007 Goodyear Ave, Gadsden, AL 35903","1171 Gatewood Drive Auburn, AL 36830"
-0.6797747055811572,78.4,"617 Becker Ave, Belen, NM 87002","4801 Beckner Rd, Santa Fe, NM 87507"
-0.679622846289513,172.5,"18111 Lexington Blvd, Sugar Land, TX 77479","11811 Blanco Road San Antonio, TX 78216"
-0.6791998850822379,30.9,"2 Wake Robin Rd, Lincoln, RI 02865","Plains Rd & Tootell Rd, Kingston, RI 02881"
-0.6791998850822379,10.9,"10180 Washington Ave, Sturtevant, WI 53177","6308 8th Avenue, Kenosha, WI 53143"
-0.6788710907704042,227.0,"1600 E Evergreen St, Cameron, MO 64429","4400 Telegraph Rd, St. Louis, MO 63129"
-0.6786944752061032,86.7,"11567 Canterwood Blvd, Gig Harbor, WA 98332","1615 Delaware St. Longview, WA 98632"
-0.6786006069094305,204.5,"2401 S 31st St, Temple, TX 76508","450 N 11th St, Beaumont, TX, 77702"
-0.6782142857142857,194.6,"1825 4th St, SF, CA 94158","1441 Liberty St., Redding, CA 96001"
-0.6780264279624894,33.8,"695 W Boughton Rd, Bolingbrook, IL 60440","450 W Hwy 22, Barrington, IL 60010"
-0.6780091253775464,238.4,"64 Belinda Pkwy 200A, Mt. Juliet, TN 37122","1 Medical Park Blvd, Bristol, TN 37260"
-0.67786391042205,7.9,"870 N Milwaukee Ave, Vernon Hills, IL 60061","777 Park Ave. West, Highland Park, IL 60035"
-0.6777804590304589,62.0,"509 W 18th St, Hermann, MO 65041","6900 Chippewa St, St. Louis, MO 63109"
-0.67752849002849,0.1,"8144 NW Prairie View Rd, KCMO, MO 64152","8144 NW PRAIRIE VIEW ROAD, KANSAS CITY, MO 64151"
-0.6773504273504273,8.8,"740 US-1, Woodbridge Township, NJ 08830","1000 Morris Ave, Union, NJ 07083"
-0.6772117993688059,23.4,"1133 Eagles Landing Pkwy, Stockbridge, GA 30281","8203 Hazelbrand Rd NE, Covington, GA 30014"
-0.6771940796331041,185.6,"1235 E Cherokee St, Springfield, MO 65804","10923 Olive Blvd, Creve Coeur, MO 63141"
-0.6771171171171172,24.4,"333 SW Cutoff, Northborough, MA 01532","1 Patriot Place, Foxborough, MA 02035"
-0.676971256971257,186.7,"3801 S National Ave, Springfield, MO 65807","3871 Mexico Rd, St. Charles, MO 63303"
-0.6764957264957264,108.3,"2240 Iyannough Rd, Barnstable, MA 02668","40 Wright St, Palmer, MA 01069"
-0.6764069264069263,83.7,"1675 Highland Ave, Madison, WI 53792","10400 75th St., Kenosha, WI 53142"
-0.6764069264069263,186.7,"3501 Johnson St, Hollywood, FL 33021","4200 Conroy Rd, Orlando, FL 32839"
-0.6758297258297259,177.7,"1101 Ocilla Rd, Douglas, GA 31533","1000 Rowland St, Clarkston GA 30021"
-0.6757703081232492,345.2,"6255 Sharlands Ave, Reno, NV 89523","6125 W Sahara Ave #1B, Las Vegas, NV 89146"
-0.6756829227417462,310.4,"960 N San Antonio Rd 101, Los Altos, CA 94022","10250 Santa Monica Blvd #1450, Los Angeles, CA 90067"
-0.6753418803418804,160.4,"130 E Lockling Ave, Brookfield, MO 64628","10923 Olive Blvd, Creve Coeur, MO 63141"
-0.6753418803418804,279.0,"2105 Airline Dr, Bossier City, LA 71111","1419 Basin Street, New Orleans, LA 70116"
-0.6752270563246173,100.0,"101 Chestnut St, Jefferson City, MO 65101","6900 Chippewa St, St. Louis, MO 63109"
-0.6751727804359383,36.4,"885 Roosevelt Rd, Glen Ellyn, IL 60137","7900 Rollins Rd. Gurnee, IL 60031"
-0.6751349009413525,71.0,"300 S Byron Blvd, Chamberlain, SD 57325","513 3rd St SW, Wagner, SD 57380"
-0.6749158249158249,94.2,"155 Crystal Run Rd, Middletown, NY 10941","4417 Vestal Pkwy E, Vestal, NY 13850"
-0.6746031746031745,350.3,"280 Vista Knoll Pkwy, Reno, NV 89506","1125 Shadow Ln, Las Vegas, NV, 89102"
-0.6745540321391714,197.6,"3440 W Dr Martin Luther King Jr Blvd 100, Tampa, FL 33607","347 Don Shula Dr., Miami Gardens, FL 33056"
-0.6741403299542835,87.9,"9230 Sky Island Dr E, Bonney Lake, WA 98391","2320 Freeway Dr. Mount Vernon, WA 98273"
-0.674089068825911,4.9,"352 Peachtree Pl NW, Atlanta, GA 30318","6 Executive Park Drive NE, Atlanta, GA"
-0.673945373945374,130.4,"9601 Baptist Health Dr, Little Rock, AR 72205","141 Betty Drive Pocahontas, AR, 72455"
-0.6735585585585585,262.3,"4000 N Illinois Ln, Swansea, IL 62226","2400 N Ashland Avenue, Chicago, IL 60614"
-0.6734808401475068,1.2,", South Kingstown, RI 02881","Plains Rd & Tootell Rd, Kingston, RI 02881"
-0.6723443223443223,104.2,"1600 E Broadway, Columbia, MO 65201","600 NE Adams Dairy Pkwy #200, Blue Springs, MO 64014"
-0.6719718190306425,74.1,"801 Delaware Ave, Camden, NJ 08102","617 Broad Street Newark, NJ 07102"
-0.6718233618233619,46.9,"2 Centerock Rd, West Nyack, NY 10994","101 Nicolls Road, Stony Brook, NY 11794"
-0.6717171717171717,25.4,"1305 Jennings Mill Rd, Watkinsville, GA 30677","1255 Friendship Rd #130, Braselton, GA 30517"
-0.6716628652112523,379.8,"608 Winifred St, Bayard, NM 88023","300 Wilson St Clayton, NM 88415"
-0.6714602302837598,37.3,"1 Riverview Plaza, Red Bank, NJ 07701","701 U.S. 9, Forked River, NJ 08731"
-0.6713311740600898,115.2,"2450 S Telshor Blvd, Las Cruces, NM 88011","530 De Moss Street, Lordsburg, New Mexico 88045"
-0.6711516711516712,12.5,"727 N Beers St, Holmdel, NJ 07733","315 W. Main Street Freehold, NJ 07728"
-0.6711171869066606,101.8,"131 McMillen Dr, Newark, OH 43055","7109 Bachman Dr, Sardinia, OH 45171"
-0.6709401709401709,1.7,", Lake Elsinore, CA ","500 Diamond Dr, Lake Elsinore, CA 92530"
-0.6707138590203106,16.1,"3320 Brunswick Pike, Lawrence Township, NJ 08648","2421 US-1, North Brunswick Township, NJ 08902"
-0.6704942983053929,165.8,"630 W 3rd St, Milan, MO 63556","600 Mid Rivers Mall Dr, St. Peters, MO 63376"
-0.6703703703703704,28.0,", Bellwood, IL 60104","2490 Bushwood Drive  Elgin, IL 60124"
-0.6701887151662264,213.6,"2741 NE McBaine Dr, Lee's Summit, MO 64064","12409 St. Charles Rock Rd, Bridgeton, MO 63044"
-0.6701774042950515,8.7,"1600 Antelope Dr, Layton, UT 84041","165 N University Ave, Farmington, UT 84025"
-0.6699999999999999,24.9,"2201 Chapel Ave W, Cherry Hill, NJ 08002","225 N Clinton Ave # 1, Trenton, NJ 08609"
-0.6694134325713273,32.3,"2 Jan Sebastian Dr, Sandwich, MA 02563","106 New State Hwy, Raynham, MA 02767"
-0.668939393939394,275.0,"1400 E Bert Kouns Industrial Loop, Shreveport, LA 71105","1419 Basin Street, New Orleans, LA 70116"
-0.6688994438355053,212.6,"1004 N 14th St, Leesburg, FL 34748","3700 N.W. 11th Place, Lauderhill, FL 33311"
-0.668859649122807,68.2,"18101 Oakwood Blvd, Dearborn, MI 48124","1881 W. Grand River Okemos, MI 48864"
-0.6685435435435436,36.0,"465 Marin Blvd, Jersey City, NJ 07302","315 W. Main Street Freehold, NJ 07728"
-0.6681041181041181,4.8,"1 Robert Wood Johnson Place, New Brunswick, NJ 08901","2421 US-1, North Brunswick Township, NJ 08902"
-0.6680784493284492,107.4,"6238 E Pima St, Tucson, AZ 85712","13400 E Shea Blvd, Scottsdale, AZ 85259"
-0.6680784493284492,105.6,"501 N Park Ave, Tucson, AZ 85719","13400 E Shea Blvd, Scottsdale, AZ 85259"
-0.6673254281949935,10.2,", Albuquerque, NM 87121","13701 Encantado Rd. NE Albuquerque, NM 87123"
-0.6671788166067342,61.6,"525 Long Pond Dr, Harwich, MA 02645","1600 Crown Colony Dr, Quincy, MA 02169"
-0.6671181531646648,33.2,"100 New Hampshire Ave, Portsmouth, NH 03801","24 Homestead Place, Alton, NH 03809"
-0.6670739654610621,24.7,"505 Parnassus Ave, SF, CA 94143","150 Muir Road, Martinez, CA 94553"
-0.6670739654610621,23.3,"40 75th St, Willowbrook, IL 60527","9977 Woods Dr. Skokie, IL 60077"
-0.6670621804107694,20.6,"2310 Hempstead Turnpike, East Meadow, NY 11554","234 East 149th Street, Bronx, NY 10451"
-0.6670175702433768,225.0,"1403 Grand Blvd, KCMO, MO 64106","10923 Olive Blvd, Creve Coeur, MO 63141"
-0.6668650793650794,164.6,"2650 Executive Park Dr NW 5, Cleveland, TN 37312","800 Weatherly Dr Suite 201B, Clarksville, TN 37043"
-0.6666666666666666,32.5,"25 Jack Martin Blvd, Brick Township, NJ 08724","2421 US-1, North Brunswick Township, NJ 08902"
-0.6663780663780664,131.3,", Huntington, IN 46750","601 W 2nd St, Bloomington, IN 47403"
-0.6663390526958742,213.7,"4741 S Arrowhead Dr B, Independence, MO 64055","12409 St. Charles Rock Rd, Bridgeton, MO 63044"
-0.6662267471091,27.3,"15 Metropolitan Grove Rd, Gaithersburg, MD 20878","10251 Central Ave, Largo, MD 20774"
-0.6661730082782714,102.2,"1 Hospital Dr, Columbia, MO 65201","13861 Manchester Rd, Ballwin, MO 63011"
-0.6658730158730158,61.5,"5131 O'Donovan Dr, Baton Rouge, LA 70808","1111 Greengate Dr., Suite B  Covington, LA 70433"
-0.6656926406926407,7.3,"55 Hazel Ruby Ln, Mt Hope, WV 25880","520 Beckley Crossing Shopping Center, Beckley, WV 25801"
-0.6652977652977653,47.3,"18 E Laurel Rd, Stratford, NJ 08084","315 W. Main Street Freehold, NJ 07728"
-0.664983164983165,44.3,"2 Essex Center Dr, Peabody, MA 01960","211 Park Street, Attleboro, MA 02703"
-0.6647620672010915,124.0,"117 N Chalkville Rd, Trussville, AL 35173","101 L.V. Stabler Drive, Greenville, AL 36037"
-0.6646579690057951,16.6,"125 Sunrise Hwy, West Islip, NY 11795","101 Nicolls Road, Stony Brook, NY 11794"
-0.6646579690057951,103.7,"202 E Nifong Blvd, Columbia, MO 65203","10923 Olive Blvd, Creve Coeur, MO 63141"
-0.6645401382243488,39.3,"2 Dunning St, Claremont, NH 03743","75 Laconia Road, Tilton, NH 03276"
-0.6642857142857143,66.5,"3322 College Dr, Vineland, NJ 08360","215 Applegarth Road Monroe, NJ 08831"
-0.6642857142857143,63.1,"686 NJ-70, Brick Township, NJ 08723","562 NJ-23, Pompton Plains, NJ 07444"
-0.6641025641025641,39.0,"2 North Rd Unit E & F, Chester, NJ 07930","225 N Clinton Ave # 1, Trenton, NJ 08609"
-0.6636379236379236,184.1,"227 E Chestnut Expy, Springfield, MO 65802","3871 Mexico Rd, St. Charles, MO 63303"
-0.6636101820884429,54.3,"1125 Louisiana 30 W, Gonzales, LA 70737","1419 Basin Street, New Orleans, LA 70116"
-0.6634644234598409,131.3,"98 Cohen Walker Dr, Warner Robins, GA 31088","960 Joe Frank Harris Pkwy, Cartersville, GA 30120"
-0.6626262626262626,6.6,", San Jose, CA ","4150 N 1st St, San Jose, CA 95134"
-0.66243961352657,65.8,"5 Richland Medical Park Dr, Columbia, SC 29203","1656 Riverchase Blvd., #2400 Rock Hill, SC 29732"
-0.6623283459725354,107.7,"4280 N Oracle Rd, Tucson, AZ 85705","5920 W McDowell Rd Phoenix, Arizona 85035"
-0.6622937785728483,3.7,"493 Doctor M.L.K. Jr Ave, Memphis, TN 38126","2400 Poplar Ave #501, Memphis, TN 38112"
-0.6619699042407661,259.2,"1923 N Dal Paso St Suite B, Hobbs, NM 88240","1691 Galisteo St, Ste D, Santa Fe, New Mexico 87505"
-0.6619291194738766,321.5,"9850 W St Lukes Dr, Nampa, ID 83687","520 N 3rd Ave, Sandpoint, ID 83864"
-0.6611449177372098,90.5,"4440 W 95th St, Oak Lawn, IL 60453","403 E 1st St, Dixon, IL 61021"
-0.6611008039579468,19.7,"2624 County Rd 516, Old Bridge Township, NJ 08857","27 S Cooksbridge Road Suite 1-5 Jackson, NJ 08527"
-0.6602252252252252,7.1,"1600 Medical Pkwy, Carson City, NV 89703","900 E. Long St. Carson City, NV 89706"
-0.6601579691010585,24.2,"340 Southwest Blvd, Kansas City, KS 66103","1100 N 4th St Leavenworth, Kansas 66042"
-0.6599341490982359,11.1,"8200 LA-23, Belle Chasse, LA 70037","2000 Segnette Blvd, Westwego, LA 70094"
-0.6597434390912652,74.6,"3600 Florida Blvd, Baton Rouge, LA 70806","576 North Avenue G, Crowley, LA 70526"
-0.6596864552272522,46.5,"145 Queen St, Bristol, CT 06010","34 Maple Street, Norwalk, CT"
-0.6594776594776596,160.7,"12000 MS-15 1, Philadelphia, MS 39350","11700 Highway 57 Vancleave, MS 39565"
-0.6591251885369532,22.6,"68 Robbins St, Waterbury, CT 06708","95 Loucust Ave, Danbury CT"
-0.6590236748376282,189.4,"7001 Gulf Hwy, Lake Charles, LA 70607","6801 Franklin Avenue, New Orleans, LA 70148"
-0.6588888888888889,82.9,"901 Long Beach Blvd, Ship Bottom, NJ 08008","480 Pompton Avenue, Suite 6, Cedar Grove, NJ 07009"
-0.6580952380952382,55.6,"250 Old Hook Rd, Westwood, NJ 07675","501 Squankum Yellowbrook Rd, Farmingdale, NJ 07727"
-0.6578111444778112,54.9,"85 Godwin Ave, Midland Park, NJ 07432","501 Squankum Yellowbrook Rd, Farmingdale, NJ 07727"
-0.6575854700854701,15.3,", San Mateo, CA ","1998 Market St, San Francisco, CA 94102"
-0.6573363828289936,59.8,"17609 Old Jefferson Hwy B, Prairieville, LA 70769","1419 Basin Street, New Orleans, LA 70116"
-0.6561253561253562,50.1,"380 Parkland Plaza, Ann Arbor, MI 48103","1210 W Saginaw St, Lansing, MI 48915"
-0.6559218559218559,28.0,"1520 W 53rd St, Davenport, IA 52806","841 Springdale Drive, Clinton, IA 52732"
-0.6556482670089858,126.8,"1106 Interstate Dr, Bloomington, IL 61705","2100 Pfingsten Road, Glenview IL 60026"
-0.6551801801801802,197.5,"4602 Eastpark Blvd, Madison, WI 53718","2049 15th Ave, Cameron, WI 54822"
-0.6544117647058824,6.9,"2929 S Garnett Rd, Tulsa, OK 74129","315 South Utica, Tulsa, Ok 74104"
-0.6542950513538749,379.1,"126 Tatum Hwy, Lovington, NM 88260","801 W Maple St, Farmington, NM 87401"
-0.6540517961570593,102.2,"800 Hospital Dr, Columbia, MO 65201","13861 Manchester Rd, Ballwin, MO 63011"
-0.6539554506306424,16.9,"71 Haynes St, Manchester, CT 06040","28 Crescent Street Middletown, CT 06457"
-0.6534090909090909,100.2,"3617 Northwest Expy, Oklahoma City, OK 73112","315 South Utica, Tulsa, Ok 74104"
-0.6527777777777777,182.6,"10524 Euclid Ave C Building, Cleveland, OH 44195","1801 Edwin C. Moses Blvd, Dayton, OH"
-0.6527777777777777,147.6,"1570 E Tucson Marketplace Blvd, Tucson, AZ 85713","3457 W White Mountain Blvd Lakeside, AZ 85929"
-0.6527777777777777,204.8,"1315 Burro Ave, Cloudcroft, NM 88317","1183 Diamond Drive, Los Alamos, New Mexico 87544"
-0.6522357723577236,11.3,"16525 Holly Crest Ln 120, Huntersville, NC 28078","6570 Bruton Smith Blvd, Concord, NC 28027"
-0.6522337722337723,184.0,"1710 S Slappey Blvd, Albany, GA 31701","7221 Sallie Mood Dr, Savannah, GA 31406"
-0.6519465977605513,73.8,"11315 Bridgeport Way SW, Lakewood, WA 98499","1615 Delaware St. Longview, WA 98632"
-0.6516087516087515,34.0,"2801 FL-7, Margate, FL 33063","2515 W Flagler Street Miami, FL 33135"
-0.6510606060606061,32.0,"530 New Brunswick Ave, Perth Amboy, NJ 08861","225 N Clinton Ave # 1, Trenton, NJ 08609"
-0.6502291589248111,80.8,"500 Cahaba Park Cir 100, Birmingham, AL 35242","80 William E. Hill Drive, Carrollton, AL 35447"
-0.6501652153826066,20.0,"444 Cajundome Blvd, Lafayette, LA 70506","576 North Avenue G, Crowley, LA 70526"
-0.6486443381180224,325.4,"865 Anthony Dr, Anthony, NM 88021","356 9th St, Cimarron, NM 87714"
-0.6483870967741935,22.8,"757 Boston Post Rd E, Marlboro, MA 01752","1 Hospital Dr, Lowell, MA 01852"
-0.6480986333927511,0.5,"3000 Triumph Blvd, Lehi, UT 84043","3249 N 1200 W Ste A Lehi, UT 84043"
-0.6479302832244008,210.5,"44201 Dequindre Rd, Troy, MI 48085","224 Park Avenue, Frankfort, MI 49635"
-0.6476190476190476,74.3,"9005 US-64 101, Arlington, TN 38002","6501 Telecom Drive, Milan, TN 38358"
-0.6475128735998301,91.9,"380 John Fitch Hwy, Fitchburg, MA 01420","100 Ter Heun Dr, Falmouth, MA 02540"
-0.647307924984876,84.2,"420 IL-173, Antioch, IL 60002","403 E 1st St, Dixon, IL 61021"
-0.647297772155457,92.4,"3001 General Pershing Blvd, Oklahoma City, OK 73107","3090 State Highway 97, Sand Springs, OK 74063"
-0.6462962962962963,270.3,"874 Barnes Crossing Rd, Tupelo, MS 38804","3882 Bienville Boulevard Ocean Springs, MS  39564-5803"
-0.646295733252255,8.9,"3900 Aviation Cir NW, Atlanta, GA 30336",515 Garson Drive Atlanta GA 30324
-0.6455648926237162,0.8,"349 Broadway, Somerville, MA 02145","33 Tower Street, Somerville MA"
-0.6452380952380952,12.6,"594 Great Rd 102A, North Smithfield, RI 02896","1195 N Main St  Providence, RI 02904"
-0.6447245564892623,3.7,", Sacramento, CA ","1600 Exposition Blvd, Sacramento, CA 95815"
-0.6440170940170941,96.4,"401 W Blue Starr Dr, Claremore, OK 74017","1400 E College Ave, McAlester, OK 74501"
-0.6439665075998586,31.5,"100 W 7th St, Okmulgee, OK 74447","6030 S 66th East Avenue, Tulsa, Ok, 74145"
-0.6435185185185185,336.6,"18653 Wedge Pkwy, Reno, NV 89511","1125 Shadow Ln, Las Vegas, NV, 89102"
-0.6428035178035177,60.8,"1621 W 10th St, Little Rock, AR 72202","110 North Drew Street, Star City, AR 71667"
-0.642063492063492,112.9,"117 Camino De Vida, Santa Rosa, NM 88435","1183 Diamond Drive, Los Alamos, New Mexico 87544"
-0.6404761904761904,73.6,"950 E Washington St, Baton Rouge, LA 70802","1419 Basin Street, New Orleans, LA 70116"
-0.6404083570750237,140.0,"Shuffield Dr & Jack Stephens Dr, Little Rock, AR 72205","2158 Butterfield Coach Rd #100, Springdale, AR 72764"
-0.6393537414965986,114.3,"University Blvd & 22nd St S, Birmingham, AL 35205","674 Hicks Industrial Blvd, Union Springs, AL 36089"
-0.6388888888888888,16.3,", Harrison, AR 72601","609 Clark St, Jasper, AR 72641"
-0.6386128364389233,51.5,"989 Governors Ln UNIT 180, Lexington, KY 40513","1006 New Moody Lane  La Grange, KY 40031"
-0.6376343482005767,264.1,"298 W Mariposa Rd, Nogales, AZ 85621","2446 Fort Tuthill Loop, Flagstaff, AZ 86004"
-0.6368446368446369,20.4,"575 NJ-440, Jersey City, NJ 07305","1376 NJ-36, Hazlet, NJ 07730"
-0.6359477124183006,12.6,"589 Bedford St, Stamford, CT 06901","88 North Ave, Westport CT"
-0.6359141126158233,29.8,"435 Hurffville - Cross Keys Rd, Washington Township, NJ 08080","4403 E Black Horse Pike Mays Landing, NJ 08330"
-0.6356724617594183,104.9,"1625 N Campbell Ave, Tucson, AZ 85719","13400 E Shea Blvd, Scottsdale, AZ 85259"
-0.6354341736694678,259.2,"1923 N Dal Paso St, Hobbs, NM 88240","1691 Galisteo St, Ste D, Santa Fe, New Mexico 87505"
-0.6351760108565916,30.7,"5070 Ion Dr, Sparks, NV 89436","900 E. Long St. Carson City, NV 89706"
-0.6341384863123994,210.3,", Pompano Beach, FL ","960 S Williamson Blvd, Daytona Beach, FL 32114"
-0.6336048967627915,343.9,"901 Adams Blvd, Boulder City, NV 89005","900 E. Long St. Carson City, NV 89706"
-0.6334126984126985,128.5,"9525 E Old Spanish Trail, Tucson, AZ 85748","18589 N 59th Ave Glendale, Arizona 85308"
-0.6326797385620915,26.5,", New Rochelle, NY 10805","777 Seaview Ave, Staten Island, NY 10305"
-0.6319390430098234,95.4,"1202 US-60, Socorro, NM 87801","2669 N Scenic Dr, Alamogordo, NM 88310"
-0.6318388908526766,16.3,"13616 E 103rd St N, Owasso, OK 74055","6030 S 66th East Avenue, Tulsa, Ok, 74145"
-0.6312330623306233,124.6,"5369 S Calle Santa Cruz, Tucson, AZ 85706","18589 N 59th Ave Glendale, Arizona 85308"
-0.6307338335640224,185.1,"111 Kansas City Rd, Ruidoso, NM 88345","2010 Industrial Park Road, Espanola, New Mexico 87532"
-0.6302005012531328,1.6,"One Hospital Plaza, Stamford, CT 06902","460 Shippan Ave, Stamford CT"
-0.6297619047619047,159.8,", ,  ","435 State Rd, , Route 6, North Dartmouth, MA, 02747, USA"
-0.6270630836668573,7.0,"Meeker Ave & Elizabeth Ave, Newark, NJ 07112","464 Eagle Rock Avenue, Suite C, West Orange, NJ 07052"
-0.6250136165577342,10.4,"Princeton Hightstown Rd & NJ-64, West Windsor Township, NJ 08550","2421 US-1, North Brunswick Township, NJ 08902"
-0.6239588871167818,267.4,"407 Interchange Dr, Fulton, MS 38843","2819 Denny Avenue Pascagoula, MS 39581"
-0.6239588871167818,29.3,"3601 W 13 Mile Rd, Royal Oak, MI 48073","5301 McAuley Dr, Ypsilanti, MI 48197"
-0.6231481481481481,112.3,", LaGrange, IN 46761","5165 McCarty Ln, Lafayette, IN 47905"
-0.6221197793538219,10.1,"1 Hospital Plaza, Old Bridge Township, NJ 08857","215 Applegarth Road Monroe, NJ 08831"
-0.62140522875817,245.2,"3075 N Reserve St Suite Q, Missoula, MT 59808","710 11th St N, Columbus, MT, 59019"
-0.6210170176235924,131.1,"54 Hospital Dr 111, Osage Beach, MO 65065","12409 St. Charles Rock Rd, Bridgeton, MO 63044"
-0.6185636856368563,130.7,", Kendallville, IN 46755","1 W Athenian Dr, Crawfordsville, IN 47933"
-0.6177109440267335,93.2,"2500 Jacksboro Pike 6, Jacksboro, TN 37757","2000 Brookside Dr, Kingsport, TN 37660"
-0.6175983436853002,32.9,"479 County Rd 520, Marlboro Township, NJ 07746","399 Route 10 East Hanover, NJ 07936"
-0.6128618693134822,34.8,", Homewood, IL 60430","9977 Woods Dr. Skokie, IL 60077"
-0.6113786443243807,253.0,"3rd Ave SW & 4th St SW, Rochester, MN 55902","1245 Washington Ave, Detroit Lakes, MN 56501"
-0.6052836052836054,36.0,", Warsaw, IN ","301 E Day Rd, Mishawaka, IN 46545"
-0.605079365079365,192.0,", Columbia City, IN 46725","8204 County Rd 311, Sellersburg, IN  47172"
-0.6039377289377289,42.5,"2280 E Calvada Blvd 301, Pahrump, NV 89048","5580 W Flamingo Rd, Las Vegas, NV 89103"
-0.6028231028231028,64.9,", Wabash, IN 46992","301 E Day Rd, Mishawaka, IN 46545"
-0.6018518518518519,110.0,"3700 4th St SW, Mason City, IA 50401","2103 Ingersoll Ave, Des Moines, IA 50312"
-0.6012457912457913,43.0,"25327 US-27 SUITE 204-205, Leesburg, FL 34748","36245 U.S. Highway 27, Haines City, FL 33844"
-0.5944741532976826,8.7,"1500 US-41, Schererville, IN 46375","1201 South Main Street Crown Point, IN 46307"
-0.5867978770455551,18.0,"484 MA-134, Dennis, MA 02660","483 Great Neck Rd S, Mashpee, MA 02649"
-0.5835748792270531,26.0,", Davis, CA ","1320 Travis Blvd, Suite C, Fairfield, CA 94533"
-0.5733199262611027,20.5,", Auburn, IN 46706","700 Broadway, Fort Wayne, IN 46802"
-0.5724526369687659,218.3,", , CA ","1305 CA-1, Long Beach, CA 90806"
-0.5571428571428572,3.9,", Stamford, CT 06902","80 High School Ln, Darien, CT 06820"
-0.5553352265308787,32.4,"E 42nd Ave & Lake Otis Pkwy, Anchorage, AK 99508","3122 E Meridian Park Lp.  Wasilla, AK"
-0.511136346430464,229.7,"1650 Cowles St, Fairbanks, AK 99701","3122 E Meridian Park Lp.  Wasilla, AK"
-0.5018315018315018,25.2,", , AZ ","600 S Dobson Rd Chandler, Arizona 85224"
-0.5,166.9,", , TN 37870","2104 Dayton Ave, Nashville, TN 37210"
-0.4932603057603058,230.5,"800 Noble St, Fairbanks, AK 99701","3122 E Meridian Park Lp.  Wasilla, AK"
--,-,"993 Av. San Luis, Arecibo, Arecibo 00612",-
--,-,"10 Calle Casia, San Juan, San Juan 00921",-
--,-,", San Juan, San Juan 00925",-
--,-,"#12 Calle Santiago Riera Palmer, Salinas, Salinas 00751",-
--,-,", Ponce, Ponce 00728",-
--,-,"43 Calle Juan R. Garzot, Naguabo, Naguabo 00718",-
--,-,", , Luquillo 00773",-
--,-,"48 Cll 65 De Infanteria, Añasco, Añasco 00610",-
--,-,"109 Cll Fernández Garcia, Luquillo, Luquillo 00773",-
--,-,", San Juan, Guaynabo 00920",-
--,-,", Añasco, Añasco 00610",-
--,-,", , Aguadilla 00603",-
--,-,", , Corozal ",-
--,-,", Arecibo, Arecibo 00612",-
--,-,"16 Calle Gándara, Corozal, Corozal 00783",-
--,-,", Aguada, Aguada ",-
+Jaro-Winkler (address),Geo Distance,SB - Addr,SB - Name,Closest CAC Match - Addr,Closest CAC Match - Name
+0.4932603057603058,230.5,"800 Noble St, Fairbanks, AK 99701",Fairbanks' Foundation Health Partners - Drive- Thru,"3122 E Meridian Park Lp.  Wasilla, AK",Capstone Clinic
+0.511136346430464,229.7,"1650 Cowles St, Fairbanks, AK 99701",Fairbanks Memorial Hospital,"3122 E Meridian Park Lp.  Wasilla, AK",Capstone Clinic
+0.5553352265308787,32.4,"E 42nd Ave & Lake Otis Pkwy, Anchorage, AK 99508",Lake Otis Parkway Drive-Thru,"3122 E Meridian Park Lp.  Wasilla, AK",Capstone Clinic
+0.5867978770455551,18.0,"484 MA-134, Dennis, MA 02660",CareWell Urgent Care-South Dennis,"483 Great Neck Rd S, Mashpee, MA 02649",Wampanoag Health Service Unit - Federally-Recognized Tribal Members Only
+0.5944741532976826,8.7,"1500 US-41, Schererville, IN 46375",Midwest Express Clinic Schererville,"1201 South Main Street Crown Point, IN 46307",Franciscan Health Crown Point
+0.6012457912457913,43.0,"25327 US-27 SUITE 204-205, Leesburg, FL 34748",Premier Medical Associates,"36245 U.S. Highway 27, Haines City, FL 33844",BayCare Urgent Care (Haines City)
+0.6018518518518519,110.0,"3700 4th St SW, Mason City, IA 50401",North Iowa Event Center (MercyOne North Iowa),"2103 Ingersoll Ave, Des Moines, IA 50312",Adult Respiratory Illness Clinic (Urgent Care - Ingersoll)
+0.6039377289377289,42.5,"2280 E Calvada Blvd 301, Pahrump, NV 89048",Serenity Mental Health,"5580 W Flamingo Rd, Las Vegas, NV 89103",Convenient Care at Flamingo Healthcare Center
+0.6113786443243807,253.0,"3rd Ave SW & 4th St SW, Rochester, MN 55902",Mayo Clinic,"1245 Washington Ave, Detroit Lakes, MN 56501",Sanford Health Detroit Lakes Clinic & Same Day Surgery Center
+0.6175983436853002,32.9,"479 County Rd 520, Marlboro Township, NJ 07746",Immediate Care at the Marlboro Medical Arts Building,"399 Route 10 East Hanover, NJ 07936",CityMD Urgent Care – East Hanover
+0.6177109440267335,93.2,"2500 Jacksboro Pike 6, Jacksboro, TN 37757",EastLake Urgent Care,"2000 Brookside Dr, Kingsport, TN 37660",Indian Path Community Hospital
+0.6210170176235924,131.1,"54 Hospital Dr 111, Osage Beach, MO 65065",Lake Regional Health System,"12409 St. Charles Rock Rd, Bridgeton, MO 63044",Bridgeton
+0.62140522875817,245.2,"3075 N Reserve St Suite Q, Missoula, MT 59808",Grant Creek Family Medicine,"710 11th St N, Columbus, MT, 59019",Stillwater Billings Clinic
+0.6221197793538219,10.1,"1 Hospital Plaza, Old Bridge Township, NJ 08857",Raritan Bay Medical Center Old Bridge,"215 Applegarth Road Monroe, NJ 08831",Hackensack Meridian Urgent Care - Monroe
+0.6239588871167818,29.3,"3601 W 13 Mile Rd, Royal Oak, MI 48073","Beaumont Hospital, Royal Oak","5301 McAuley Dr, Ypsilanti, MI 48197",St. Joseph Mercy Ann Arbor
+0.6239588871167818,267.4,"407 Interchange Dr, Fulton, MS 38843",MedPlus Family and Urgent Care,"2819 Denny Avenue Pascagoula, MS 39581",Singing River Medical Clinic
+0.6250136165577342,10.4,"Princeton Hightstown Rd & NJ-64, West Windsor Township, NJ 08550",InFocus Urgent Care,"2421 US-1, North Brunswick Township, NJ 08902",PM Pediatrics
+0.6270630836668573,7.0,"Meeker Ave & Elizabeth Ave, Newark, NJ 07112",Weequahic Park,"464 Eagle Rock Avenue, Suite C, West Orange, NJ 07052",American Family Care Urgent Care
+0.6302005012531328,1.6,"One Hospital Plaza, Stamford, CT 06902",Stamford Hospital,"460 Shippan Ave, Stamford CT",Drive Thru Coronovirus Testing Stamford
+0.6307338335640224,185.1,"111 Kansas City Rd, Ruidoso, NM 88345",NMDOH SE Region - Ruidoso Public Health Office,"2010 Industrial Park Road, Espanola, New Mexico 87532",NMDOH NE Region - Rio Arriba Public Health Office
+0.6312330623306233,124.6,"5369 S Calle Santa Cruz, Tucson, AZ 85706",Next Care Urgent Care - Tucson (S. Calle Santa Cruz),"18589 N 59th Ave Glendale, Arizona 85308",NextCare Urgent Care
+0.6318388908526766,16.3,"13616 E 103rd St N, Owasso, OK 74055",Next Care Urgent Care - Owasso,"6030 S 66th East Avenue, Tulsa, Ok, 74145",Access Family Medical
+0.6319390430098234,95.4,"1202 US-60, Socorro, NM 87801",Presbyterian - Socorro General Hospital - Socorro Medical Group Clinic,"2669 N Scenic Dr, Alamogordo, NM 88310",Gerald Champion Regional Medical Center
+0.6334126984126985,128.5,"9525 E Old Spanish Trail, Tucson, AZ 85748",Next Care Urgent Care - Tucson (E. Old Spanish Trail),"18589 N 59th Ave Glendale, Arizona 85308",NextCare Urgent Care
+0.6336048967627915,343.9,"901 Adams Blvd, Boulder City, NV 89005",Boulder City Hospital,"900 E. Long St. Carson City, NV 89706",Carson City Health & Human Services
+0.6351760108565916,30.7,"5070 Ion Dr, Sparks, NV 89436",Saint Mary's Medical Group - Spanish Springs,"900 E. Long St. Carson City, NV 89706",Carson City Health & Human Services
+0.6354341736694678,259.2,"1923 N Dal Paso St, Hobbs, NM 88240",Nor-Lea Hospital District – Hobbs Medical Clinic,"1691 Galisteo St, Ste D, Santa Fe, New Mexico 87505",Southwest CARE - Southwest CARE Center - Pediatrics
+0.6356724617594183,104.9,"1625 N Campbell Ave, Tucson, AZ 85719",Banner Health,"13400 E Shea Blvd, Scottsdale, AZ 85259",Mayo Clinc drive-up coronavirus testing Scottsdale
+0.6359141126158233,29.8,"435 Hurffville - Cross Keys Rd, Washington Township, NJ 08080",Jefferson Washington Township Hospital,"4403 E Black Horse Pike Mays Landing, NJ 08330",Hamilton Mall - Drive-Thru
+0.6359477124183006,12.6,"589 Bedford St, Stamford, CT 06901",Murphy Medical Associates,"88 North Ave, Westport CT",Drive Thru Coronovirus Testing Westport/Weston
+0.6368446368446369,20.4,"575 NJ-440, Jersey City, NJ 07305",Jersey City - West - Drive Thru,"1376 NJ-36, Hazlet, NJ 07730",Immediate Care Medical Walk-In of Hazlet
+0.6376343482005767,264.1,"298 W Mariposa Rd, Nogales, AZ 85621",Next Care Urgent Care - Nogales,"2446 Fort Tuthill Loop, Flagstaff, AZ 86004",The Coconino County Department of Health and Human Services drive-up coronavirus swab testing
+0.6386128364389233,51.5,"989 Governors Ln UNIT 180, Lexington, KY 40513",Bluegrass Extended Care Medicine,"1006 New Moody Lane  La Grange, KY 40031",Baptist Health Urgent Care - LaGrange
+0.6393537414965986,114.3,"University Blvd & 22nd St S, Birmingham, AL 35205",University of Alabama at Birmingham,"674 Hicks Industrial Blvd, Union Springs, AL 36089",Bullock County Health Department
+0.6404083570750237,140.0,"Shuffield Dr & Jack Stephens Dr, Little Rock, AR 72205",UAMS Health,"2158 Butterfield Coach Rd #100, Springdale, AR 72764",Northwest Health Urgent Care - Eastside
+0.6404761904761904,73.6,"950 E Washington St, Baton Rouge, LA 70802",Metro Health Education,"1419 Basin Street, New Orleans, LA 70116",Mahalia Jackson Theater Parking Lot
+0.642063492063492,112.9,"117 Camino De Vida, Santa Rosa, NM 88435",Guadalupe County Hospital,"1183 Diamond Drive, Los Alamos, New Mexico 87544",NMDOH NE Region - Los Alamos Public Health Office
+0.6428035178035177,60.8,"1621 W 10th St, Little Rock, AR 72202",Arkansas Children's Hospital,"110 North Drew Street, Star City, AR 71667",MAINLINE HEALTH SYSTEMS INC.
+0.6435185185185185,336.6,"18653 Wedge Pkwy, Reno, NV 89511",Saint Mary's Medical Group - Galena,"1125 Shadow Ln, Las Vegas, NV, 89102",UNLV Medicine
+0.6439665075998586,31.5,"100 W 7th St, Okmulgee, OK 74447",Access Solutions Medical Group - Okmulgee,"6030 S 66th East Avenue, Tulsa, Ok, 74145",Access Family Medical
+0.6440170940170941,96.4,"401 W Blue Starr Dr, Claremore, OK 74017",Next Care Urgent Care - Claremore,"1400 E College Ave, McAlester, OK 74501",Oklahoma Health Department
+0.6452380952380952,12.6,"594 Great Rd 102A, North Smithfield, RI 02896",North Smithfield Urgent Care,"1195 N Main St  Providence, RI 02904",Ocean State Urgent Care - East Side
+0.6455648926237162,0.8,"349 Broadway, Somerville, MA 02145",CareWell Urgent Care-Somerville,"33 Tower Street, Somerville MA",Somerville Hospital - Crown St. parking Test Center
+0.646295733252255,8.9,"3900 Aviation Cir NW, Atlanta, GA 30336",Aviation Cultural Center,515 Garson Drive Atlanta GA 30324,Passion City Church
+0.6462962962962963,270.3,"874 Barnes Crossing Rd, Tupelo, MS 38804",MedPlus Family and Urgent Care,"3882 Bienville Boulevard Ocean Springs, MS  39564-5803",Memorial Surgery Center Ocean Springs
+0.647297772155457,92.4,"3001 General Pershing Blvd, Oklahoma City, OK 73107",Oklahoma State Fairgrounds,"3090 State Highway 97, Sand Springs, OK 74063",Access Solutions Medical Group-Sand Springs
+0.647307924984876,84.2,"420 IL-173, Antioch, IL 60002",PromptMed Urgent Care- Antioch,"403 E 1st St, Dixon, IL 61021",KSB Hospital
+0.6475128735998301,91.9,"380 John Fitch Hwy, Fitchburg, MA 01420",CareWell Urgent Care- Fichburg,"100 Ter Heun Dr, Falmouth, MA 02540",Falmouth Hospital - Triage Tent
+0.6476190476190476,74.3,"9005 US-64 101, Arlington, TN 38002",Woman’s Healthcare Associates,"6501 Telecom Drive, Milan, TN 38358",Milan Clinic
+0.6479302832244008,210.5,"44201 Dequindre Rd, Troy, MI 48085","Beaumont Hospital, Troy","224 Park Avenue, Frankfort, MI 49635",Paul Oliver Memorial Hospital
+0.6480986333927511,0.5,"3000 Triumph Blvd, Lehi, UT 84043",Mountain Point Medical Center,"3249 N 1200 W Ste A Lehi, UT 84043",Lehi Clinic Instacare
+0.6483870967741935,22.8,"757 Boston Post Rd E, Marlboro, MA 01752",CareWell Urgent Care-Marlborough,"1 Hospital Dr, Lowell, MA 01852",Lowell General Hospital
+0.6486443381180224,325.4,"865 Anthony Dr, Anthony, NM 88021",NMDOH SW Region - Anthony Public Health Office,"356 9th St, Cimarron, NM 87714",Cimarron Healthcare Clinic
+0.6501652153826066,20.0,"444 Cajundome Blvd, Lafayette, LA 70506",The Cajundome,"576 North Avenue G, Crowley, LA 70526",Crowley Cares Family Clinic
+0.6502291589248111,80.8,"500 Cahaba Park Cir 100, Birmingham, AL 35242",Urgent Care for Children - Highway 280,"80 William E. Hill Drive, Carrollton, AL 35447",Pickens County Health Department
+0.6510606060606061,32.0,"530 New Brunswick Ave, Perth Amboy, NJ 08861",Raritan Bay Medical Center Perth Amboy,"225 N Clinton Ave # 1, Trenton, NJ 08609",Trenton Police Department Headquarters
+0.6516087516087515,34.0,"2801 FL-7, Margate, FL 33063",Northwest Medical Center,"2515 W Flagler Street Miami, FL 33135",TEST Miami Center - FDOH in Miami-Dade
+0.6519465977605513,73.8,"11315 Bridgeport Way SW, Lakewood, WA 98499",St. Clare Hospital,"1615 Delaware St. Longview, WA 98632",PeaceHealth St. John Medical Center
+0.6522337722337723,184.0,"1710 S Slappey Blvd, Albany, GA 31701",Dougherty County Health Department,"7221 Sallie Mood Dr, Savannah, GA 31406",Jennifer Ross Soccer Complex
+0.6522357723577236,11.3,"16525 Holly Crest Ln 120, Huntersville, NC 28078",Novant Health Lakeside Family Physicians,"6570 Bruton Smith Blvd, Concord, NC 28027",ZMax Dragway and Atrium Health
+0.6527777777777777,182.6,"10524 Euclid Ave C Building, Cleveland, OH 44195","Cleveland Clinic - Main Campus, W.O Walker Building","1801 Edwin C. Moses Blvd, Dayton, OH",Premier Health Mobile Testing - Univ of Dayton Arena Parking Lot
+0.6527777777777777,147.6,"1570 E Tucson Marketplace Blvd, Tucson, AZ 85713",Next Care Urgent Care - Kino,"3457 W White Mountain Blvd Lakeside, AZ 85929",Banner Urgent Care - Lakeside
+0.6527777777777777,204.8,"1315 Burro Ave, Cloudcroft, NM 88317",Susan Bruce - Bloom and Grow Pediatrics,"1183 Diamond Drive, Los Alamos, New Mexico 87544",NMDOH NE Region - Los Alamos Public Health Office
+0.6534090909090909,100.2,"3617 Northwest Expy, Oklahoma City, OK 73112",Next Care Urgent Care - Oklahoma City (NW Expressway),"315 South Utica, Tulsa, Ok 74104",Tulsa Health Department
+0.6539554506306424,16.9,"71 Haynes St, Manchester, CT 06040",Manchester Memorial Hospital,"28 Crescent Street Middletown, CT 06457",Middlesex Health
+0.6540517961570593,102.2,"800 Hospital Dr, Columbia, MO 65201",Harry S. Truman Memorial Veterans' Hospital (VA),"13861 Manchester Rd, Ballwin, MO 63011",Town and Country
+0.6542950513538749,379.1,"126 Tatum Hwy, Lovington, NM 88260",Nor-Lea General Hospital,"801 W Maple St, Farmington, NM 87401",San Juan Regional Medical Center
+0.6544117647058824,6.9,"2929 S Garnett Rd, Tulsa, OK 74129",Next Care Urgent Care - Tulsa (Garnett),"315 South Utica, Tulsa, Ok 74104",Tulsa Health Department
+0.6551801801801802,197.5,"4602 Eastpark Blvd, Madison, WI 53718",UW Health at The American Center,"2049 15th Ave, Cameron, WI 54822",Mayo Clinic Health System - Northland - Cameron
+0.6556482670089858,126.8,"1106 Interstate Dr, Bloomington, IL 61705",McLean county fairgrounds,"2100 Pfingsten Road, Glenview IL 60026",Glenbrook Hospital
+0.6559218559218559,28.0,"1520 W 53rd St, Davenport, IA 52806",Genesis Health System,"841 Springdale Drive, Clinton, IA 52732",Gateway Surgery Center
+0.6561253561253562,50.1,"380 Parkland Plaza, Ann Arbor, MI 48103",Michigan Medicine/West Ann Arbor Health Center,"1210 W Saginaw St, Lansing, MI 48915",Sparrow Hospital St. Lawrence Campus
+0.6573363828289936,59.8,"17609 Old Jefferson Hwy B, Prairieville, LA 70769",St. Elizabeth Hospital,"1419 Basin Street, New Orleans, LA 70116",Mahalia Jackson Theater Parking Lot
+0.6578111444778112,54.9,"85 Godwin Ave, Midland Park, NJ 07432",Excel Urgent Care of Midland Park,"501 Squankum Yellowbrook Rd, Farmingdale, NJ 07727",Central New Jersey Urgent Care Testing Howell NJ
+0.6580952380952382,55.6,"250 Old Hook Rd, Westwood, NJ 07675",Pascack Valley Medical Center,"501 Squankum Yellowbrook Rd, Farmingdale, NJ 07727",Central New Jersey Urgent Care Testing Howell NJ
+0.6588888888888889,82.9,"901 Long Beach Blvd, Ship Bottom, NJ 08008",Hackensack Meridian Urgent Care - Long Beach Island,"480 Pompton Avenue, Suite 6, Cedar Grove, NJ 07009",American Family Care Urgent Care
+0.6590236748376282,189.4,"7001 Gulf Hwy, Lake Charles, LA 70607",The Burton Complex,"6801 Franklin Avenue, New Orleans, LA 70148",University of New Orleans Lakefront Arena Parking Lot
+0.6591251885369532,22.6,"68 Robbins St, Waterbury, CT 06708",Waterbury Hospital,"95 Loucust Ave, Danbury CT",Danbury Hospital
+0.6594776594776596,160.7,"12000 MS-15 1, Philadelphia, MS 39350",Neshoba General Hospital,"11700 Highway 57 Vancleave, MS 39565",Singing River Health System Vancleave Clinic
+0.6596864552272522,46.5,"145 Queen St, Bristol, CT 06010",Bristol Hospital,"34 Maple Street, Norwalk, CT",Norwalk Hospital
+0.6597434390912652,74.6,"3600 Florida Blvd, Baton Rouge, LA 70806",Baton Rouge General Medical Center,"576 North Avenue G, Crowley, LA 70526",Crowley Cares Family Clinic
+0.6599341490982359,11.1,"8200 LA-23, Belle Chasse, LA 70037",Belle Chasse Community Health Center,"2000 Segnette Blvd, Westwego, LA 70094","Alario Center, Westwego"
+0.6601579691010585,24.2,"340 Southwest Blvd, Kansas City, KS 66103",Sharon Lee Family Health Clinic,"1100 N 4th St Leavenworth, Kansas 66042",NextCare Urgent Care - Leavenworth
+0.6602252252252252,7.1,"1600 Medical Pkwy, Carson City, NV 89703",Carson Tahoe Regional Medical Center,"900 E. Long St. Carson City, NV 89706",Carson City Health & Human Services
+0.6611008039579468,19.7,"2624 County Rd 516, Old Bridge Township, NJ 08857",Excel Urgent Care of Old Bridge,"27 S Cooksbridge Road Suite 1-5 Jackson, NJ 08527",Hackensack Meridian Urgent Care - Jackson
+0.6611449177372098,90.5,"4440 W 95th St, Oak Lawn, IL 60453",Advocate Christ Medical Center,"403 E 1st St, Dixon, IL 61021",KSB Hospital
+0.6619291194738766,321.5,"9850 W St Lukes Dr, Nampa, ID 83687",St. Luke's Nampa Medical Center,"520 N 3rd Ave, Sandpoint, ID 83864",Bonner General Health
+0.6619699042407661,259.2,"1923 N Dal Paso St Suite B, Hobbs, NM 88240",NMDOH SE Region - Hobbs Public Health Office,"1691 Galisteo St, Ste D, Santa Fe, New Mexico 87505",Southwest CARE - Southwest CARE Center - Pediatrics
+0.6622937785728483,3.7,"493 Doctor M.L.K. Jr Ave, Memphis, TN 38126",Care Memphis Clinic,"2400 Poplar Ave #501, Memphis, TN 38112",Christ Community Health Services Women's Center
+0.6623283459725354,107.7,"4280 N Oracle Rd, Tucson, AZ 85705",Next Care Urgent Care - Tucson (N. Oracle Rd),"5920 W McDowell Rd Phoenix, Arizona 85035",NextCare Urgent Care
+0.66243961352657,65.8,"5 Richland Medical Park Dr, Columbia, SC 29203",Prisma Health Richland Hospital North Portal,"1656 Riverchase Blvd., #2400 Rock Hill, SC 29732",Atrium Health Shiland Family Medicine
+0.6634644234598409,131.3,"98 Cohen Walker Dr, Warner Robins, GA 31088",Houston County Health Department,"960 Joe Frank Harris Pkwy, Cartersville, GA 30120",Cartersville Medical Center
+0.6636101820884429,54.3,"1125 Louisiana 30 W, Gonzales, LA 70737",OUR LADY OF THE LAKE,"1419 Basin Street, New Orleans, LA 70116",Mahalia Jackson Theater Parking Lot
+0.6636379236379236,184.1,"227 E Chestnut Expy, Springfield, MO 65802",The Springfield-Greene County Health Department Testing Site,"3871 Mexico Rd, St. Charles, MO 63303",St. Charles
+0.6641025641025641,39.0,"2 North Rd Unit E & F, Chester, NJ 07930",Excel Urgent Care of Chester,"225 N Clinton Ave # 1, Trenton, NJ 08609",Trenton Police Department Headquarters
+0.6642857142857143,66.5,"3322 College Dr, Vineland, NJ 08360",Rowan College Cumberland Campus,"215 Applegarth Road Monroe, NJ 08831",Hackensack Meridian Urgent Care - Monroe
+0.6642857142857143,63.1,"686 NJ-70, Brick Township, NJ 08723",The Doctors' Office Urgent Care of Brick,"562 NJ-23, Pompton Plains, NJ 07444",PM Pediatrics
+0.6645401382243488,39.3,"2 Dunning St, Claremont, NH 03743",Valley Regional Urgent Care,"75 Laconia Road, Tilton, NH 03276",ClearChoiceMD Urgent Care
+0.6646579690057951,16.6,"125 Sunrise Hwy, West Islip, NY 11795",AFC Urgent Care West Islip,"101 Nicolls Road, Stony Brook, NY 11794",Stony Brook Hospital
+0.6646579690057951,103.7,"202 E Nifong Blvd, Columbia, MO 65203","Providence Urgent Care: Columbia, MO (Nifong Blvd.)","10923 Olive Blvd, Creve Coeur, MO 63141",Creve Coeur
+0.6647620672010915,124.0,"117 N Chalkville Rd, Trussville, AL 35173",Urgent Care for Children - Trussville,"101 L.V. Stabler Drive, Greenville, AL 36037",American Family Care Clinic-Greenville
+0.664983164983165,44.3,"2 Essex Center Dr, Peabody, MA 01960",Atrius Health: Peabody Site,"211 Park Street, Attleboro, MA 02703",Sturdy Memorial Hospital
+0.6652977652977653,47.3,"18 E Laurel Rd, Stratford, NJ 08084",Jefferson Stratford Hospital,"315 W. Main Street Freehold, NJ 07728",Hackensack Meridian Urgent Care - Freehold
+0.6656926406926407,7.3,"55 Hazel Ruby Ln, Mt Hope, WV 25880",J.W. And Hazel Ruby West Virginia Welcome Center,"520 Beckley Crossing Shopping Center, Beckley, WV 25801",MedExpress Urgent Care
+0.6658730158730158,61.5,"5131 O'Donovan Dr, Baton Rouge, LA 70808",OUR LADY OF THE LAKE PEDIATRICS,"1111 Greengate Dr., Suite B  Covington, LA 70433",Ochsner Urgent Care & Occupational Health- Covington
+0.6661730082782714,102.2,"1 Hospital Dr, Columbia, MO 65201",MU Health,"13861 Manchester Rd, Ballwin, MO 63011",Town and Country
+0.6662267471091,27.3,"15 Metropolitan Grove Rd, Gaithersburg, MD 20878",MDOT MVA Vehicle Inspection/Emission Center: Gaithersburg,"10251 Central Ave, Largo, MD 20774",Motor Vehicle Administration
+0.6663390526958742,213.7,"4741 S Arrowhead Dr B, Independence, MO 64055",Urgent Care of Kansas City,"12409 St. Charles Rock Rd, Bridgeton, MO 63044",Bridgeton
+0.6666666666666666,32.5,"25 Jack Martin Blvd, Brick Township, NJ 08724",Ocean Medical Center,"2421 US-1, North Brunswick Township, NJ 08902",PM Pediatrics
+0.6668650793650794,164.6,"2650 Executive Park Dr NW 5, Cleveland, TN 37312",Physician Services,"800 Weatherly Dr Suite 201B, Clarksville, TN 37043",Vanderbilt Primary Care Clarksville
+0.6670175702433768,225.0,"1403 Grand Blvd, KCMO, MO 64106",Northwell Health/GoHealth Urgent Care Centers,"10923 Olive Blvd, Creve Coeur, MO 63141",Creve Coeur
+0.6670621804107694,20.6,"2310 Hempstead Turnpike, East Meadow, NY 11554",AFC Urgent Care East Meadow,"234 East 149th Street, Bronx, NY 10451",Lincoln Hospital
+0.6670739654610621,23.3,"40 75th St, Willowbrook, IL 60527",Midwest Express Clinic Willowbrook,"9977 Woods Dr. Skokie, IL 60077",NorthShore Immediate Care Center - Skokie at Old Orchard Woods
+0.6670739654610621,24.7,"505 Parnassus Ave, SF, CA 94143",UC San Francisco,"150 Muir Road, Martinez, CA 94553",Martinez Outpatient Clinic and Community Living Center
+0.6671181531646648,33.2,"100 New Hampshire Ave, Portsmouth, NH 03801",Convenient MD - Pease International Tradeport,"24 Homestead Place, Alton, NH 03809",ClearChoiceMD Urgent Care
+0.6671788166067342,61.6,"525 Long Pond Dr, Harwich, MA 02645",Cape Cod Healthcare Urgent Care - Harwich,"1600 Crown Colony Dr, Quincy, MA 02169","Harvard Pilgrim Healthcare, Quincy"
+0.6680784493284492,107.4,"6238 E Pima St, Tucson, AZ 85712",Next Care Urgent Care - Tucson (E. Pima St),"13400 E Shea Blvd, Scottsdale, AZ 85259",Mayo Clinc drive-up coronavirus testing Scottsdale
+0.6680784493284492,105.6,"501 N Park Ave, Tucson, AZ 85719",Next Care Urgent Care - Tucson (N. Park Ave),"13400 E Shea Blvd, Scottsdale, AZ 85259",Mayo Clinc drive-up coronavirus testing Scottsdale
+0.6681041181041181,4.8,"1 Robert Wood Johnson Place, New Brunswick, NJ 08901",Robert Wood Johnson University Hospital,"2421 US-1, North Brunswick Township, NJ 08902",PM Pediatrics
+0.6685435435435436,36.0,"465 Marin Blvd, Jersey City, NJ 07302",Jersey City - East - Walk Up,"315 W. Main Street Freehold, NJ 07728",Hackensack Meridian Urgent Care - Freehold
+0.668859649122807,68.2,"18101 Oakwood Blvd, Dearborn, MI 48124","Beaumont Hospital, Dearborn","1881 W. Grand River Okemos, MI 48864",Redicare Okemos
+0.6688994438355053,212.6,"1004 N 14th St, Leesburg, FL 34748",Premier Medical Associates,"3700 N.W. 11th Place, Lauderhill, FL 33311",Central Broward Park & Broward County Stadium
+0.668939393939394,275.0,"1400 E Bert Kouns Industrial Loop, Shreveport, LA 71105",CHRISTUS Health System,"1419 Basin Street, New Orleans, LA 70116",Mahalia Jackson Theater Parking Lot
+0.6694134325713273,32.3,"2 Jan Sebastian Dr, Sandwich, MA 02563",Cape Cod Healthcare Urgent Care - Sandwich,"106 New State Hwy, Raynham, MA 02767",Health Express - Raynham
+0.6699999999999999,24.9,"2201 Chapel Ave W, Cherry Hill, NJ 08002",Jefferson Cherry Hill Hospital,"225 N Clinton Ave # 1, Trenton, NJ 08609",Trenton Police Department Headquarters
+0.6701774042950515,8.7,"1600 Antelope Dr, Layton, UT 84041",Davis Hospital and Medical Center,"165 N University Ave, Farmington, UT 84025",Farmington Health Center
+0.6701887151662264,213.6,"2741 NE McBaine Dr, Lee's Summit, MO 64064",NextCare Urgent Care,"12409 St. Charles Rock Rd, Bridgeton, MO 63044",Bridgeton
+0.6704942983053929,165.8,"630 W 3rd St, Milan, MO 63556",Sullivan County Memorial Hospital,"600 Mid Rivers Mall Dr, St. Peters, MO 63376",St. Peters
+0.6707138590203106,16.1,"3320 Brunswick Pike, Lawrence Township, NJ 08648",Quaker Bridge Mall,"2421 US-1, North Brunswick Township, NJ 08902",PM Pediatrics
+0.6711171869066606,101.8,"131 McMillen Dr, Newark, OH 43055",Licking Memorial Hospital,"7109 Bachman Dr, Sardinia, OH 45171",Sardinia Family Medicine
+0.6711516711516712,12.5,"727 N Beers St, Holmdel, NJ 07733",Bayshore Medical Center,"315 W. Main Street Freehold, NJ 07728",Hackensack Meridian Urgent Care - Freehold
+0.6713311740600898,115.2,"2450 S Telshor Blvd, Las Cruces, NM 88011",MMC - Memorial Medical Center,"530 De Moss Street, Lordsburg, New Mexico 88045",Lordsburg Public Health Office
+0.6714602302837598,37.3,"1 Riverview Plaza, Red Bank, NJ 07701",Riverview Medical Center,"701 U.S. 9, Forked River, NJ 08731",Hackensack Meridian Urgent Care-Forked River
+0.6716628652112523,379.8,"608 Winifred St, Bayard, NM 88023",Silver City Health Care Clinic - Bayard,"300 Wilson St Clayton, NM 88415",Union County General Hospital
+0.6717171717171717,25.4,"1305 Jennings Mill Rd, Watkinsville, GA 30677",Oconee Health Campus,"1255 Friendship Rd #130, Braselton, GA 30517",North Atlanta Primary Care Braselton
+0.6718233618233619,46.9,"2 Centerock Rd, West Nyack, NY 10994",Crystal Run Healthcare,"101 Nicolls Road, Stony Brook, NY 11794",Stony Brook Hospital
+0.6719718190306425,74.1,"801 Delaware Ave, Camden, NJ 08102",Cooper's Poynt Waterfront Park,"617 Broad Street Newark, NJ 07102",CityMD Urgent Care – Newark
+0.6723443223443223,104.2,"1600 E Broadway, Columbia, MO 65201",Boone Hospital,"600 NE Adams Dairy Pkwy #200, Blue Springs, MO 64014",Saint Luke's Health Systems - Primary Care
+0.6735585585585585,262.3,"4000 N Illinois Ln, Swansea, IL 62226",Former Siteman Cancer Center,"2400 N Ashland Avenue, Chicago, IL 60614",Innovative Express Care
+0.673945373945374,130.4,"9601 Baptist Health Dr, Little Rock, AR 72205",Baptist Health Little Rock,"141 Betty Drive Pocahontas, AR, 72455","1st Choice Health Systems, Inc."
+0.674089068825911,4.9,"352 Peachtree Pl NW, Atlanta, GA 30318",Georgia Tech- CVS Testing site,"6 Executive Park Drive NE, Atlanta, GA",Emory Healthcare Testing Site
+0.6741403299542835,87.9,"9230 Sky Island Dr E, Bonney Lake, WA 98391",Franciscan Medical Pavilion,"2320 Freeway Dr. Mount Vernon, WA 98273",Skagit Regional Acute Respiratory Clinic - Riverbend
+0.6745540321391714,197.6,"3440 W Dr Martin Luther King Jr Blvd 100, Tampa, FL 33607",BayCare Urgent Care (Tampa),"347 Don Shula Dr., Miami Gardens, FL 33056",Hard Rock Stadium
+0.6746031746031745,350.3,"280 Vista Knoll Pkwy, Reno, NV 89506",Saint Mary's Medical Group - North Valleys,"1125 Shadow Ln, Las Vegas, NV, 89102",UNLV Medicine
+0.6749158249158249,94.2,"155 Crystal Run Rd, Middletown, NY 10941",Crystal Run Healthcare,"4417 Vestal Pkwy E, Vestal, NY 13850",UHS Walk-In Vestal
+0.6751349009413525,71.0,"300 S Byron Blvd, Chamberlain, SD 57325",Sanford Chamberlain Medical Center,"513 3rd St SW, Wagner, SD 57380",Wagner Community Memorial Hospital Avera
+0.6751727804359383,36.4,"885 Roosevelt Rd, Glen Ellyn, IL 60137",Northwestern Medicine Immediate Care Glen Ellyn,"7900 Rollins Rd. Gurnee, IL 60031",NorthShore Immediate Care Center - Gurnee
+0.6752270563246173,100.0,"101 Chestnut St, Jefferson City, MO 65101",Missouri Health Laboratory,"6900 Chippewa St, St. Louis, MO 63109",St. Louis Hills
+0.6753418803418804,160.4,"130 E Lockling Ave, Brookfield, MO 64628",Pershing Memorial Hospital,"10923 Olive Blvd, Creve Coeur, MO 63141",Creve Coeur
+0.6753418803418804,279.0,"2105 Airline Dr, Bossier City, LA 71111",Willis Knighton Innovation Center,"1419 Basin Street, New Orleans, LA 70116",Mahalia Jackson Theater Parking Lot
+0.6756829227417462,310.4,"960 N San Antonio Rd 101, Los Altos, CA 94022",Stanford Primary Care in Los Altos,"10250 Santa Monica Blvd #1450, Los Angeles, CA 90067",Forward Clinic at Century City
+0.6757703081232492,345.2,"6255 Sharlands Ave, Reno, NV 89523",Saint Mary's Medical Group - Northwest Reno,"6125 W Sahara Ave #1B, Las Vegas, NV 89146",Sahara West Urgent Care & Wellness
+0.6758297258297259,177.7,"1101 Ocilla Rd, Douglas, GA 31533",Coffee Regional Medical Center,"1000 Rowland St, Clarkston GA 30021",Clarkston Ministry Center Testing Site
+0.6764069264069263,186.7,"3501 Johnson St, Hollywood, FL 33021",Memorial Healthcare System,"4200 Conroy Rd, Orlando, FL 32839",The Mall at Millenia
+0.6764069264069263,83.7,"1675 Highland Ave, Madison, WI 53792",American Family Children's Hospital,"10400 75th St., Kenosha, WI 53142",Aurora Medical Center Kenosha
+0.6764957264957264,108.3,"2240 Iyannough Rd, Barnstable, MA 02668",Cape Cod Community College,"40 Wright St, Palmer, MA 01069",Baystate Wing Hospital
+0.676971256971257,186.7,"3801 S National Ave, Springfield, MO 65807",South Cox Hospital - West Pavilion,"3871 Mexico Rd, St. Charles, MO 63303",St. Charles
+0.6771171171171172,24.4,"333 SW Cutoff, Northborough, MA 01532",CareWell Urgent Care-Northborough,"1 Patriot Place, Foxborough, MA 02035",Gilette Stadium Parking Lot
+0.6771940796331041,185.6,"1235 E Cherokee St, Springfield, MO 65804",Mercy Hospital Springfield,"10923 Olive Blvd, Creve Coeur, MO 63141",Creve Coeur
+0.6772117993688059,23.4,"1133 Eagles Landing Pkwy, Stockbridge, GA 30281",Piedmont Henry,"8203 Hazelbrand Rd NE, Covington, GA 30014",Newton County Health Dept
+0.6773504273504273,8.8,"740 US-1, Woodbridge Township, NJ 08830",Excel Urgent Care of Iselin,"1000 Morris Ave, Union, NJ 07083",Kean University
+0.67752849002849,0.1,"8144 NW Prairie View Rd, KCMO, MO 64152",First Point Urgent Care MO,"8144 NW PRAIRIE VIEW ROAD, KANSAS CITY, MO 64151",Firest Point Urgent Care
+0.6777804590304589,62.0,"509 W 18th St, Hermann, MO 65041",Hermann Area District Hospital,"6900 Chippewa St, St. Louis, MO 63109",St. Louis Hills
+0.67786391042205,7.9,"870 N Milwaukee Ave, Vernon Hills, IL 60061",Northwestern Medicine Immediate Care Vernon Hills,"777 Park Ave. West, Highland Park, IL 60035",Highland Park Hospital
+0.6780091253775464,238.4,"64 Belinda Pkwy 200A, Mt. Juliet, TN 37122",Vanderbilt Health Walk-In Clinic Mt. Juliet,"1 Medical Park Blvd, Bristol, TN 37260",Bristol Regional Medical Center
+0.6780264279624894,33.8,"695 W Boughton Rd, Bolingbrook, IL 60440",Walgreen's,"450 W Hwy 22, Barrington, IL 60010",Advocate Good Shepherd Hospital
+0.6782142857142857,194.6,"1825 4th St, SF, CA 94158",UC San Francisco,"1441 Liberty St., Redding, CA 96001",Redding Rancheria Tribal Health Center
+0.6786006069094305,204.5,"2401 S 31st St, Temple, TX 76508",Baylor Scott & White Clinic – Temple,"450 N 11th St, Beaumont, TX, 77702",Legacy Central Beaumont
+0.6786944752061032,86.7,"11567 Canterwood Blvd, Gig Harbor, WA 98332",St. Anthony Hospital,"1615 Delaware St. Longview, WA 98632",PeaceHealth St. John Medical Center
+0.6788710907704042,227.0,"1600 E Evergreen St, Cameron, MO 64429",Cameron Regional Medical Center,"4400 Telegraph Rd, St. Louis, MO 63129",Oakville
+0.6791998850822379,10.9,"10180 Washington Ave, Sturtevant, WI 53177",Ascension Wisconsin Health Center – Mount Pleasant Urgent Care,"6308 8th Avenue, Kenosha, WI 53143",Froedtert Kenosha Hospital
+0.6791998850822379,30.9,"2 Wake Robin Rd, Lincoln, RI 02865",Lincoln Urgent Care,"Plains Rd & Tootell Rd, Kingston, RI 02881",University of Rhode Island - Kingston
+0.679622846289513,172.5,"18111 Lexington Blvd, Sugar Land, TX 77479",Smart Financial Centre at Sugar Land,"11811 Blanco Road San Antonio, TX 78216",Texas MedClinic - Blanco / Parliament
+0.6797747055811572,78.4,"617 Becker Ave, Belen, NM 87002",NMDOH NW Region - Belen Public Health Office,"4801 Beckner Rd, Santa Fe, NM 87507",Presbyterian Santa Fe Medical Center
+0.6805555555555555,100.0,"1007 Goodyear Ave, Gadsden, AL 35903",Gadsden Regional Medical Center,"1171 Gatewood Drive Auburn, AL 36830",East Alabama Medical Center Healthplus Center-Auburn
+0.6805712669683258,0.0,"S Oakes St & E Beauregard Ave, San Angelo, TX 76903",Shannon Medical Center,"101-199 S Oakes St San Angelo, TX 76903",Shannon Health
+0.6810397353875614,40.7,"7600 River Rd, North Bergen, NJ 07047",Palisades Medical Center,"2040 Route 33 Neptune City, NJ 07753",Hackensack Meridian Urgent Care - Neptune City
+0.6811147186147185,71.6,"53 Academy Dr, Westampton, NJ 08060",Burlington County Emergency Services Training Center,"300 Pompton Road Wayne, NJ 07470",William Paterson University
+0.6812159058283088,5.1,"1101 Medical Center Blvd, Marrero, LA 70072",West Jeff Medical Center- Marrero,"1419 Basin Street, New Orleans, LA 70116",Mahalia Jackson Theater Parking Lot
+0.6812409812409812,1.3,"2 Renshaw Rd, Darien, CT 06820",Murphy Medical Associates,"80 High School Ln, Darien, CT 06820",Drive Thru Coronovirus Testing Darien High School
+0.6812636165577342,311.8,"200 E Chisum St, Roswell, NM 88203",NMDOH SE Region - Roswell Public Health Office,"801 W Maple St, Farmington, NM 87401",San Juan Regional Medical Center
+0.6818575761952911,110.1,"211 St Francis Dr, Cape Girardeau, MO 63703",Saint Francis Medical Center,"12409 St. Charles Rock Rd, Bridgeton, MO 63044",Bridgeton
+0.6825396825396824,2.7,"3500 Knoxville Zoo Dr, Knoxville, TN 37914",Zoo Knoxville,"140 Dameron Avenue   Knoxville, TN 37917-6413",Knox County Health Department
+0.6826516897081413,257.3,"1 Ocean Pkwy, Wantagh, NY 11793",Jones Beach State Park - Theodore Roosevelt Nature Center,"1001 West St, Carthage, NY 13619",Carthate Area Hospital
+0.6826617826617826,110.0,"1220 Iyannough Rd, Barnstable, MA 02601",Cape Cod Healthcare Urgent Care - Hyannis,"40 Wright St, Palmer, MA 01069",Baystate Wing Hospital
+0.6827485380116959,133.7,"1500 Idalia Rd B, Bernalillo, NM 87004",NMDOH NW Region - Sandoval Public Health Office,"801 W Maple St, Farmington, NM 87401",San Juan Regional Medical Center
+0.682785841609371,166.2,"1933 Edwin Dr, Chesapeake, VA 23322",Sentara Edinburgh Diagnostic Center,"8008 Westpark Dr, McLean, VA 22102",Kaiser Permanente Tysons Corner
+0.6829409578770193,680.8,"5115 El Paso Dr, El Paso, TX 79905",El Paso Department of Public Health,"136 E Hospital Dr., Angleton TX,  77515",UTMB Health Access Center
+0.6837320574162679,235.3,"7943 Moffett Rd, Semmes, AL 36575",Greater Mobile Urgent Care - Semmes,"320 Main St, Roanoke, AL 36274",Randolph County Health Department
+0.684041394335512,100.5,"127 Anderson St STE 101, Pittsburgh, PA 15212",Central Outreach Wellness Center - North Shore Location,"761 Johnsonburg Rd Suite 160, St Marys, PA 15857",Penn Highlands QCare St. Marys
+0.6840541495896745,236.4,"4412 Kell W Blvd, Wichita Falls, TX 76309",Harmony Clinics,"600 N Bell Blvd, Cedar Park, TX 78613",Cedar Park VA Clinic
+0.6840601503759399,19.0,"110 E Ridgewood Ave, Paramus, NJ 07652",The Doctors' Office Urgent Care of Paramus,"399 Route 10 East Hanover, NJ 07936",CityMD Urgent Care – East Hanover
+0.6840601503759399,18.9,"230 E Ridgewood Ave, Paramus, NJ 07652",Bergen New Bridge Medical Center - Bergen County First Responders ONLY,"399 Route 10 East Hanover, NJ 07936",CityMD Urgent Care – East Hanover
+0.6844834307992204,93.1,"1170 N Solano Dr, Las Cruces, NM 88001",NMDOH SW Region - Las Cruces Public Health Office,"2610 N. Silver, Silver City, New Mexico 88061",Grant County Public Health Office
+0.6845234708392604,58.3,"800 Spruce St, Philadelphia, PA 19107",Pennsylvania Hospital,"850 Greenfield Rd, Lancaster, PA 17601",Pennsylvania College of Health Sciences
+0.6852826510721247,15.8,"33 Kilmer Rd, Edison, NJ 08817",NJ MVC Kilmer Inspection Center,"215 Applegarth Road Monroe, NJ 08831",Hackensack Meridian Urgent Care - Monroe
+0.6852941176470587,114.7,"660 Firetower Rd, Dublin, GA 31021",Dublin Laurens County Recreation Center,"210 Forest Hill Drive Hamilton, GA 31811",Harris County Health Department
+0.6854367854367854,216.5,"2201 Mt Zion Pkwy, Morrow, GA 30260",Childrens at Mount Zion - Morrow,"7221 Sallie Mood Dr, Savannah, GA 31406",Jennifer Ross Soccer Complex
+0.6856957207834401,7.4,"350 S Waukegan Rd, Deerfield, IL 60015",Northwestern Medicine Immediate Care Deerfield,"1775 Dempster Street, Park Ridge, IL 60068",Advocate Lutheran General Hospital
+0.6857231906320265,25.2,"2500 Allen Creek Rd, Gainesville, GA 30507",Allen Creek Soccer Complex,"2570 Riverside Parkway Lawrenceville, GA 30046",Lawrenceville Drive Thru Site
+0.6860877684407095,13.4,"58 Bedford St, Lexington, MA 02421",CareWell Urgent Care-Lexington,"500 Lynnfield Street Lynn, MA 01904",North Shore Medical Union Hospital
+0.6863067926225822,34.5,"17960 S Halsted St, Homewood, IL 60430",On Dmed Urgent Care,"9600 Gross Point Road, Skokie, IL 60076",Skokie Hospital
+0.686904761904762,0.4,"1850 Gateway Dr, Sycamore, IL 60178",Northwestern Medicine Immediate Care Sycamore,"2496 DeKalb Ave.  Sycamore, IL 60178",Urgent Care DeKalb
+0.6869095816464238,42.1,"360 Station Dr, Crystal Lake, IL 60014",Northwestern Medicine Immediate Care Crystal Lake,"635 N. Fairbanks Ct, Chicago, IL 60611",Northwestern Medicine Immediate Care Streeterville
+0.6869952659426343,192.3,"55 Pacific Ave, SF, CA 94111",Carbon Health,"1035 Placer Street, Redding, CA. 96001",Shasta Community Health Center
+0.6871243914722176,60.4,"1700 Alber St 100, Wabash, IN 46992",Lutheran Health System,"1701 S Creasy Ln, Lafayette, IN 47905",Franciscan Health East
+0.6872256872256872,177.3,"1500 N Oakland Ave, Bolivar, MO 65613",Citizens Memorial Hospital,"10923 Olive Blvd, Creve Coeur, MO 63141",Creve Coeur
+0.6872951739618407,185.2,"270 E Court Ave, Selmer, TN 38375",West Tennessee Medical Group Prime Care Selmer,"701 County Service Drive Cookeville, TN 38501-3338",Putnam County Health Department
+0.6874736632876167,38.2,"18101 Prince Philip Dr, Olney, MD 20832",MedStar Montgomery Medical Center,"11 Industrial Park Drive, Waldorf, MD 20602",Waldorf VEIP COVID Testing Site
+0.6875252525252525,23.9,"116 Garden State Pkwy, Holmdel, NJ 07733",PNC Bank Arts Center,"617 Broad Street Newark, NJ 07102",CityMD Urgent Care – Newark
+0.6877145308924485,5.3,"300 Central Ave, East Orange, NJ 07018",East Orange General Hospital,"1000 Morris Ave, Union, NJ 07083",Kean University
+0.687825311942959,0.1,"516 Nizhoni Blvd, Gallup, NM 87301",Gallup Indian Medical Center (GIMC),"1919 College Drive, Gallup, New Mexico 87301",Gallup Public Health Office - McKinley County
+0.6878443848377103,3.8,"7 Blanchard Cir, Wheaton, IL 60189",Northwestern Medicine Immediate Care Wheaton,"4201 Winfield Road, Warrenville, IL 60555",Edward-Elmhurst Health - Parking Lot
+0.6878787878787879,72.7,"520 Montgomery Hwy, Vestavia Hills, AL 35216",Urgent Care for Children - Vestavia,"350 County Road 4 West, Prattville, AL 36067",Baptist Health Coronavirus Care Clinic—Prattville
+0.687966537966538,4.8,"755 N Roop St 101, Carson City, NV 89701",Serenity Mental Health,"900 E. Long St. Carson City, NV 89706",Carson City Health & Human Services
+0.6881836945304437,116.8,"10150 SE 32nd Ave, Milwaukie, OR 97222",Providence Milwuakie Memorial Hospital,"815 SW Bond Street, Bend, OR 97702",Summit Medical Group - Old Mill District
+0.6884259259259259,50.5,"525 William F McClellan Hwy, Boston, MA 02128",Suffolk Downs,"450 William S Canning Blvd. Fall River, MA 02721",Southcoast Health Urgent Care - Fall River
+0.6887289463376419,39.8,"2507 N Richmond Rd, McHenry, IL 60050",Northwestern Medicine Immediate Care McHenry,"5140 N California Ave, Chicago, IL 60625",Swedish Hospital
+0.6888047138047138,487.4,"701 S Stemmons Fwy, Lewisville, TX 75067",Clinicas Mi Doctor - Lewisville Location,"1000 Sports Park Blvd, Brownsville, TX 78526",Brownsville Sports Park
+0.6888211991078266,68.7,"135 Maple St, Decatur, GA 30030",Humanizing Medicine,"1514 Vernon Rd, Lagrange, GA 30240",WellStar West Georgia Medical Center
+0.688863287250384,141.1,"701 3rd Ave S, Clear Lake, SD 57226",Sanford Clear Lake Medical Center,"513 3rd St SW, Wagner, SD 57380",Wagner Community Memorial Hospital Avera
+0.6890977443609022,373.2,"440 N Hiawatha Dr, Canton, SD 57013",Sanford Canton-Inwood Medical Center,"1440 N Main Street Spearfish, SD 57783",Monument Health Spearfish Hospital
+0.6891133557800225,71.7,"335 E Ave K 6 B, Lancaster, CA 93535",Antelope Valley Public Health Center,"1081 N China Lake Blvd, Ridgecrest, CA 93555",Ridgecrest Regional Hospital
+0.6893217893217892,463.4,"8135 Calumet Ave, Munster, IN 46321",Midwest Express Clinic Munster,"2861 Broad Ave, Memphis, IN 38112",Christ Community Health Services Broad Avenue Health Center
+0.6896135265700484,7.7,"5950 University Ave, West Des Moines, IA 50266",The Iowa Clinic - West Des Moines Campus,"2103 Ingersoll Ave, Des Moines, IA 50312",Adult Respiratory Illness Clinic (Urgent Care - Ingersoll)
+0.6896974863726782,325.8,"215 E Hawaii Ave, Nampa, ID 83686",Saltzer Health’s Nampa,"520 N 3rd Ave, Sandpoint, ID 83864",Bonner General Health
+0.6897435897435896,51.1,"1140 NJ-72, Stafford Township, NJ 08050",Southern Ocean Medical Center,"2421 US-1, North Brunswick Township, NJ 08902",PM Pediatrics
+0.6898412698412698,4.8,"26 S Main St, Centerville, UT 84014",Centerville Health Center,"165 N University Ave, Farmington, UT 84025",Farmington Health Center
+0.689882697947214,207.6,"809 Jackson St, Burke, SD 57523",Community Memorial Hospital,"2116 Jackson Boulevard, Rapid City, SD 57702",Monument Health Rapid City Urgent Care
+0.690079667768455,53.2,"1455 Battersby Ave, Enumclaw, WA 98022",St. Elizabeth Hospital,"3927 Rucker Avenue Everett, WA 98201",the Everett Clinic Gunderson Building
+0.6902162014230978,120.5,"201 Morningside Dr, Sandersville, GA 31082",Washington County Health Department,"210 Forest Hill Drive Hamilton, GA 31811",Harris County Health Department
+0.6903371320037986,4.4,"1401 Jefferson Hwy, Jefferson, LA 70121",Oschner Center for Primary Care and Wellness,"1419 Basin Street, New Orleans, LA 70116",Mahalia Jackson Theater Parking Lot
+0.6903371320037986,44.7,"214 Center Grove Rd, Randolph, NJ 07869",County College of Morris,"225 N Clinton Ave # 1, Trenton, NJ 08609",Trenton Police Department Headquarters
+0.690446127946128,14.2,"2520 Cherry Ave, Bremerton, WA 98310",Harrison Medical Center,"720 8th Ave S, Seattle, WA 98104",International District Clinic
+0.6905723905723905,89.9,"111 Maltese Dr, Middletown, NY 10940",Middletown Medical,"1 Atwell Road, Cooperstown, NY",Basset Medical Center
+0.6906796906796907,3.2,"100 Twin River Rd, Lincoln, RI 02865",Twin River Casino - CVS MinuteClinic Mobile Testing Site,"600 Rhode Island Ave, Providence, RI 02908",Rhode Island College
+0.6906928480204342,62.5,"70 Main St, Norwich, CT 06360",Backus Hospital,"2979 Main Street, Bridgeport, CT",St. Vincent’s Medical Center
+0.6909917134456028,37.0,"9901 Medical Center Dr, Rockville, MD 20850",Adventist HealthCare Shady Grove Medical Center,"11 Industrial Park Drive, Waldorf, MD 20602",Waldorf VEIP COVID Testing Site
+0.6910602540113366,49.0,"1683 E Florence Blvd, Casa Grande, AZ 85122",Next Care Urgent Care - Casa Grande,"13400 E Shea Blvd, Scottsdale, AZ 85259",Mayo Clinc drive-up coronavirus testing Scottsdale
+0.6910629514963881,58.3,"214 Washington St, Claremont, NH 03743",Keady Family Practice,"240 S Main St, Wolfeboro, NH 03894",Huggins Hospital
+0.6912393162393161,192.8,"1100 E 3rd St, Chattanooga, TN 37403",Erlanger UT Family Practice,"1501 W. Elk Ave, Elizabethton, TN 37643",Sycamore Shoals Hospital
+0.6912657806618,12.3,"2400 Wellesley Ave NE, Albuquerque, NM 87107",NMDOH NW Region - Midtown Public Health Office,"7440 Jim McDowell Rd NW, Albuquerque, NM, 87114",Westside Emergency Housing Center
+0.6915957605612778,5.2,"1 Bay St, Montclair, NJ 07042",Mountainside Medical Center,"617 Broad Street Newark, NJ 07102",CityMD Urgent Care – Newark
+0.6920968587635254,16.0,"21 Romance Hill Rd, Belfair, WA 98528",Harrison Belfair Urgent Care,"9621 Ridgetop Blvd NW Silverdale, WA 98383",The Doctors Clinic Ridgetop East
+0.6922337722337722,288.3,"224 SE 24th St, Gainesville, FL 32641",Florida Department of Health in Alachua - Main Site - Gainesville,"1475 West 49th Place, Hialeah, FL 33012",Larkin Community Hospital - Palm Springs Campus
+0.6922799422799423,171.9,"600 Mary St, Evansville, IN 47710",Deaconess Midtown Hospital,"5165 McCarty Ln, Lafayette, IN 47905",IU Health Arnett Hospital
+0.6924963924963925,83.6,"600 Highland Ave, Madison, WI 53792",University Hospital,"10400 75th St., Kenosha, WI 53142",Aurora Medical Center Kenosha
+0.6928571428571427,163.0,"2500 Metrohealth Dr, Cleveland, OH 44109",MetroHealth Medical Center,"55 Centennial Blvd, Chillicothe OH 45601",Adena Urgent Care
+0.6930571686669248,31.6,"8600 Old Georgetown Rd, Bethesda, MD 20814",Suburban Hospital,"1601 Bowmans Farm Rd, Frederick, MD 21701",Vehicle Emissions Inspection Program (VEIP) station
+0.6930736404420615,313.4,"9311 SW State Rd 200, Ocala, FL 34481",Premier Medical Associates,"3200 W De Soto St, Pensacola, FL 32505",Brownsville Community Center
+0.6931476931476932,106.5,"334 12th Ave SE, Norman, OK 73071",Next Care Urgent Care - Norman,"433 Fairview Ave Ponca City, OK 74601",Oklahoma Health Department Drive Thru Testing-Kay County
+0.6931481481481482,90.8,"2442 Bloomingdale Ave, Valrico, FL 33596",BayCare Urgent Care (Bloomingdale),"1200 Deltona Blvd, Deltona, FL 32725",Deltona Plaza
+0.6931481481481482,257.2,"3201 S 16th St 1000, Milwaukee, WI 53215",Ascension St. Francis Medical Arts Pavilion,"1700 W Stout St, Rice Lake, WI 54868",Marshfield Medical Center - Rice Lake
+0.6931667403803626,115.4,"52 Tech Dr, Tifton, GA 31794","Southern Regional Technical College, Tifton Campus","727 54th Street Columbus, GA 31904",Cascade Hills Church
+0.6931920006516781,0.1,"400 Paramus Rd, Paramus, NJ 07652",Bergen County Community College,"Paramus Campus – Lots B & C 400 Paramus Road Paramus, NJ 07652",Bergen Community College
+0.693475239558189,59.6,"28050 Grand River Ave, Farmington Hills, MI 48336","Beaumont Hospital, Farmington Hills","3550 Pine Grove Ave., Port Huron, MI 48060",MedExpress Urgent Care Center
+0.6935669685030299,61.9,"364 Pritham Ave, Greenville, ME 04442",Northern Light CA Dean Hospital,"149 North St, Waterville, ME 04901",MaineGeneral Medical Center - Emergency Department Thayer Campus
+0.6936494461961354,229.1,"211 FM 544, Murphy, TX 75094",Sinai Urgent Care,"1410 Fry Rd., Houston, TX 77084",MD Kids Pediatrics - Fry Location
+0.6937224502203981,25.0,"801 Viney Grove Rd, Prairie Grove, AR 72753",Prairie Grove Elementary School,"601 SW Regional Airport Blvd, Bentonville, AR 72713",NW MEDICAL PLAZA BENTONVILLE
+0.6942151162790697,2.7,"777 Bannock St, Denver, CO 80204",Denver Health Main Campus,"1400 Jackson Street, Denver, Colorado 80206",National Jewish Health Main Campus
+0.6944444444444443,513.6,"7643 Painter Ave, Whittier, CA 90602",Whittier Public Health Center,"351 Hartnell Ave., Redding, CA 96001",Redding Outpatient Clinic
+0.6946696567189926,10.3,"9 Mule Rd, Toms River, NJ 08755",Hackensack Meridian Urgent Care - Toms River,"701 U.S. 9, Forked River, NJ 08731",Hackensack Meridian Urgent Care-Forked River
+0.6947876447876448,675.1,"200 W Arbor Dr, San Diego, CA 92103",UC San Diego Medical Center,"2700 Dolbeer Street, Eureka, CA 95501",St. Joseph Health
+0.6953140096618359,59.5,"10256 Old Green Bay Rd, Pleasant Prairie, WI 53158",Pleasant Prairie Clinic,"3200 Pleasant Valley Road, West Bend, WI 53095",Froedtert West Bend Hospital
+0.6954430255161045,186.9,"1216 Cameo St, Clovis, NM 88101",NMDOH SE Region - Clovis Public Health Office,"2669 N Scenic Dr, Alamogordo, NM 88310",Gerald Champion Regional Medical Center
+0.6956654456654457,24.5,"1050 E Philadelphia Ave, Gilbertsville, PA 19525",Tower Health Urgent Care,"1440 East Butler Pike, Ambler, PA 19002",Temple University Ambler - Upper Dublin Township
+0.6957125981516225,110.3,"3021 Griffin Ave, Enumclaw, WA 98022",Franciscan Medical Clinic,"2901 Squalicum Pkwy, Bellingham, WA 98225",PeaceHealth St. Joseph Medical Center
+0.6957125981516225,8.8,"3730 W 4700 S, West Valley City, UT 84118",Westridge Health Center,"389 S 900 E Salt Lake City, UT 84102",Salt Lake InstaCare
+0.6958257513096223,86.3,"2360 Hospital Dr 1, Aliquippa, PA 15001",Central Outreach Wellness Center,"621 S Main St, DuBois, PA 15801",Penn Highlands Q-Care DuBois
+0.6960317460317461,308.9,"1801 N Temple Ave, Starke, FL 32091",New River Health,"1350 NW 50 ST, Miami, FL 33142",Charles Hadley Park
+0.6962433862433862,253.0,"801 S 70th St, West Allis, WI 53214",Ascension Columbia St. Mary’s Milwaukee – Gateway Clinic,"1700 W Stout St, Rice Lake, WI 54868",Marshfield Medical Center - Rice Lake
+0.6967067067067066,3.8,"1720 S University Dr, Fargo, ND 58103",Sanford Health,"2101 Elm Street N.   Fargo, ND 58102",Fargo VA Health Care System
+0.696727373332695,272.4,"900 N Flamingo Rd, Pembroke Pines, FL 33028",C.B. Smith Park,"400 Health Park Blvd, Saint Augustine, FL 32086",Flagler Health+
+0.6972350230414747,80.5,"745 E 8th St, Winner, SD 57580",Winner Regional Hospital,"513 3rd St SW, Wagner, SD 57380",Wagner Community Memorial Hospital Avera
+0.6975524475524475,58.3,"1968 Peachtree Rd NW, Atlanta, GA 30309",Piedmont Healthcare - Atlanta,"1199 Prince Ave, Athens, GA 30606",Piedmont Athens Regional
+0.6984126984126985,46.0,"106 Bow St, Elkton, MD 21921",Union Hospital of Cecil County,"1800 Orleans St, Baltimore, MD 21287",Johns Hopkins Hospital
+0.6984901648059543,0.7,"2920 Telegraph Ave, Berkeley, CA 94705",Carbon Health,"2500 Milvia St Berkeley, CA 94704",Berkeley Urgent Care
+0.698571926158133,37.6,"65 James St, Edison, NJ 08820",JFK Medical Center,"500 Route 57 Washington, NJ 07882",Warren County Technical School
+0.6986127784447111,73.8,"2555 Judge Fran Jamieson Way, Melbourne, FL 32940",Main Office - Viera Clinic,"1245 West Granada Boulevard, Ormond Beach, FL 32174",AdventHealth Centra Care Ormond Beach
+0.6987732528909,198.3,"2151 W Spring St, Monroe, GA 30655",Piedmont Walton,"7221 Sallie Mood Dr, Savannah, GA 31406",Jennifer Ross Soccer Complex
+0.6991830065359478,241.4,"102 Mason Farm Rd, Chapel Hill, NC 27514",UNC Medical Center in Chapel Hill,"1 Hospital Rd., Cherokee, NC 28719",Cherokee Indian Hospital
+0.6993874857443073,170.7,"820 Illinois Rte 59, Bartlett, IL 60103",Northwestern Medicine Immediate Care Bartlett,"2950 South Sixth Street, Springfield, IL 62703",Respiratory Clinic at Memorial Physician Services - South Sixth
+0.6995801469485681,101.0,"1105 E Kennedy Blvd, Tampa, FL 33602",Main Health Department,"1205 S Woodland Blvd, DeLand, FL 32720",Family Health Source
+0.6999405822935234,104.9,"303 S Main St, Bluffton, IN 46714",Blufton Regional Medical Center,"703 N Main St Kouts, Indiana 46347",Kouts Health Care
+0.7000921375921377,53.9,"8490 Hwy 72 W, Madison, AL 35758",Urgent Care for Children - Madison,"1101 Hwy 72 EAST, Tuscumbia, AL 35674",Colbert County Office Complex
+0.7001984126984127,237.2,"580 W Germantown Pike, Plymouth Meeting, PA 19462",Tower Health Urgent Care,"4220 William Penn Highway, Monroeville, PA 15146",Allegheny Health Network
+0.7004138950480413,9.3,"1800 Unser Blvd NW, Albuquerque, NM 87120",Next Care Urgent Care - Unser,"5150 Journal Center Blvd. SE Albuquerque, NM 87109",OPTUM
+0.7006105006105005,80.4,"800 Professional Blvd, Dalton, GA 30720",Whitfield County Health Department,"1000 Rowland St, Clarkston GA 30021",Clarkston Ministry Center Testing Site
+0.7006468190678716,106.6,"3351 McMullen Booth Rd, Clearwater, FL 33761",BayCare Urgent Care (Countryside),"1410 Sports Blvd, Cape Coral, FL 33991",Cape Coral Sports Complex
+0.7007575757575758,79.1,"3580 W 9000 S, West Jordan, UT 84088",Jordan Valley Medical Center,"935 N 1000 W, Tremonton, UT 84337",Bear River Clinic
+0.7017104542966611,9.2,"10800 Knights Rd, Philadelphia, PA 19114",Jefferson Torresdale Hospital,"7401 Ogontz Avenue, Philadelphia, PA 19138",Rite Aid Redi Clinic
+0.702986633249791,264.4,"3807 McNutt Rd, Sunland Park, NM 88063",NMDOH SW Region - Sunland Park Public Health Office,"4801 Beckner Rd, Santa Fe, NM 87507",Presbyterian Santa Fe Medical Center
+0.7031529516994633,297.3,"930 W St Rd, Feasterville-Trevose, PA 19053",Tower Health Urgent Care,"150 West 3rd St., Erie, PA 16505",UPMC Hamot
+0.7032678806320227,31.1,"720 Boston Turnpike, Shrewsbury, MA 01545",CVS Pharmacy Shrewsbury,"1290 Tremont Street ,Roxbury, MA 02120",Whittier Street Health Center
+0.7036945812807881,77.9,"4 Jersey St, Boston, MA 02215",Atrius Health: Parking Garage Near Fenway Park,"230 Maple Street, Holyoke, MA 01040",Holyoke Health Center
+0.7036945812807881,125.8,"302 College St, Lafayette, TN 37083",Macon County Health Department at Lafayette Missionary Baptist Church,"266 Joule St, Alcoa, TN 37701",East Tennessee Medical Group
+0.7037837837837838,1.0,"4821 US-19, New Port Richey, FL 34652",BayCare Urgent Care (New Port Richey),"5355 School Rd. Port Richey, FL 34652",Gulf High School
+0.70379062362758,6.5,"7018 S Utica Ave, Tulsa, OK 74136",MCI Diagnostic Center,"315 South Utica, Tulsa, Ok 74104",Tulsa Health Department
+0.7044171444171444,251.9,"810 12th St, Hood River, OR 97031",Providence Hood River Memorial Hospital,"1108 SW 4th Street, Ontario, OR 97914",Malheur County Health Department
+0.7044642857142858,33.3,"789 Central Ave, Dover, NH 03820",Wentworth-Douglass Hospital,"1059 Canal St, Manchester, NH 03101",National Guard State Armory
+0.7044642857142858,100.5,"75 Park St, Elizabethtown, NY 12932",University of Vermont Health Network - Elizabethtown Community Hospital,"1001 West St, Carthage, NY 13619",Carthate Area Hospital
+0.7045028142589119,304.6,"2518 Mission College Blvd 101, Santa Clara, CA 95054",Stanford Primary Care in Santa Clara,"10250 Santa Monica Blvd #1450, Los Angeles, CA 90067",Forward Clinic at Century City
+0.7045478279030911,127.1,"4700 Highlands Way, Irondale, AL 35210",Church of the Highlands Grants MIll,"1350 Highway 231, Troy, AL 36081",Pike Internal Medicine
+0.7048229548229549,38.1,"54 Seven Lakes Dr, Sloatsburg, NY 10974",Harriman State Park,"3 Delaware Drive Lake Success, NY 11042",ProHEALTH Campus – Lake Success
+0.7050537538342416,13.0,"17512 Dona Michelle Dr 5, Tampa, FL 33647",BayCare Urgent Care (New Tampa),"4201 N Dale Mabry Hwy., Tampa, FL 33607",Raymond James Stadium
+0.7054838880925837,145.8,"1111 Crater Lake Ave, Medford, OR 97504",Providence Medford Memorial Hospital,"435 E Alder Street, Alsea, OR 97324",Alsea Health Care
+0.7055976430976432,177.2,"255 Lafayette Ave, Suffern, NY 10901",Good Samaritan Hospital,"160 Genesee St, Auburn, NY 13021",Cayuga County Health Department
+0.7056334622823984,22.0,"420 N West End St Suite B, Springdale, AR 72764",Elmdale Elementary,"500 S Mt Olive St #200, Siloam Springs, AR 72761",Community Clinic Siloam Springs Medical
+0.7061557605035866,11.1,"636 Raymond Dr, Naperville, IL 60563",Northwestern Medicine Immediate Care Naperville,"300 Randall Road Geneva, IL 60134",Northwestern Medicine Delnor Hospital
+0.7061557605035866,273.2,"310 S 2nd St, Tucumcari, NM 88401",NMDOH SE Region - TUCUMCARI PUBLIC HEALTH OFFICE,"801 W Maple St, Farmington, NM 87401",San Juan Regional Medical Center
+0.706215905828309,107.3,"480 W Lowder St, Macclenny, FL 32063",Main Health Department,"1360 Saxon Boulevard, Orange City, FL 32763",AdventHealth Centra Care Orange City
+0.7072733918128655,63.3,"345 Main St, Tewksbury, MA 01876",CareWell Urgent Care- Tewksbury,"40 Wright St, Palmer, MA 01069",Baystate Wing Hospital
+0.7074686638581161,49.3,"31 Union St, Vernon, CT 06066",Rockville General Hospital,"130 Division St, Derby, CT",Griffin Health COVID-19 Drive-Up Test Collection Site
+0.707548449612403,101.0,"1401 1st St W, Webster, SD 57274",Sanford Webster Medical Center,"604 1st St NE, Wessington Springs, SD 57382",Avera Weskota Memorial Hospital
+0.7076315789473684,22.5,"2001 Medical Pkwy, Annapolis, MD 21401",Anne Arundel Medical Center,"6401 America Blvd, Hyattsville, MD 20782",MedStar Health Urgent Care
+0.7078521785618818,27.7,"380 N Oxford Valley Rd, Langhorne, PA 19047",Jefferson Bucks Hospital,"250 King of Prussia Rd, Radnor, PA 19087",Radnor Coronavirus Testing Site - Penn Medicine
+0.7080139372822299,93.5,"7370 Baker St, Pittsburgh, PA 15206",Pittsburgh Zoo & PPG Aquarium,"271 Railroad Street Philipsburg, PA 16866",QCare Moshannon Valley
+0.7080597221262184,71.3,"2070 IL-50 500, Bourbonnais, IL 60914",Midwest Express Clinic Bourbonnais,"450 W Hwy 22, Barrington, IL 60010",Advocate Good Shepherd Hospital
+0.7080597221262184,199.3,"1001 W Memorial Dr, Artesia, NM 88210",NMDOH SE Region - Artesia Public Health Office,"215 S Silver Ave, Deming, NM 88030",Luna County Public Health Office
+0.7086999022482893,183.5,"5450 Fort St, Trenton, MI 48183","Beaumont Hospital, Trenton","400 Hobart St, Cadillac, MI 49601",Cadillac Hospital
+0.709090909090909,43.9,"230 E 10th St, Anniston, AL 36207",Regional Medical Center,"320 Main St, Roanoke, AL 36274",Randolph County Health Department
+0.7092592592592593,11.2,"97 Progress Blvd, Shippensburg, PA 17257",WellSpan Shippensburg Health Campus,"1000 Norland Ave, Chambersburg, PA 17201",Chambersburg Urgent Care
+0.7103918434563595,1.0,"535 Centerville Rd, Warwick, RI 02886",CareWell Urgent Care - Warwick,"400 East Ave, Warwick, RI 02886",Community College of Rhode Island - Warwick
+0.7106357694592988,63.8,"2302 College Ave, Conway, AR 72034",Conway Regional Medical Center,"309 S Edline, Altheimer, AR 72004",Altheimer Clinic
+0.7106357694592988,113.3,"1926 Oak St, Unionville, MO 63565",Putnam County Memorial Hospital,"601 S US-169, Smithville, MO 64089",Saint Luke's North Hospital-Smithville
+0.7111207505944348,2.3,"1481 W 10th St, Indianapolis, IN 46202",VA Medical Center in Indianapolis,"893 Delaware St, Indianapolis, IN 46225",Eli Lilly Drive-Thru Testing Site
+0.711417748917749,101.4,"400 E Burdick Expy, Minot, ND 58701",Trinity Medical Arts Clinic,"300 N 7th St, Bismarck, ND 58501",Sanford Medical Center
+0.711417748917749,3.7,"22 Jefferson St, Hartford, CT 06106",Hartford Hospital,"1000 Asylum Street, Hartford, CT",Saint Francis Hospital
+0.7118233618233619,26.5,"601 Concord Ave, Cambridge, MA 02138",CareWell Urgent Care-Cambridge Fresh Pond,"140 Lincoln Avenue, Haverhill, MA 01830",Holy Family Haverhill
+0.712037037037037,2.0,"2400 Unser Blvd SE, Rio Rancho, NM 87124",Rio Rancho - Rust Presbyterian,"1721 Rio Rancho Blvd. SE Rio Rancho, NM 87124",OPTUM - Rio Rancho Family Practice
+0.7123642439431913,8.4,"3400 Spruce St, Philadelphia, PA 19103",Hospital of the University of Pennsylvania,"7401 Ogontz Avenue, Philadelphia, PA 19138",Rite Aid Redi Clinic
+0.7125220458553793,26.5,"100 Medical Plaza, Lake St Louis, MO 63367",SSM St. Joseph Hospital-Lake St. Louis,"3802 S Lindbergh Blvd, St. Louis, MO 63127",Sunset Hills
+0.7131180297978096,4.0,"1 University Heights, Asheville, NC 28804","UNC Asheville Campus: Parking lot P28 on University Heights off of W.T. Weaver Boulevard, Asheville","711 New Leicester Hwy, Asheville, NC 28806",LEICESTER COMMUNITY HEALTH CENTER
+0.7136199528440907,73.5,"100 Sentara Cir, Williamsburg, VA 23188",Sentara Williamsburg Regional Medical Center,"4600 Spotsylvania Pkwy, Fredericksburg, VA 22408",Spotsyslania Regional Medical Center
+0.7139802191927291,5.9,"809 University Blvd E, Tuscaloosa, AL 35401",DCH Regional Medical Center,"9070 Highway 69 South, Tuscaloosa, AL 35405",American Family Care Clinic-Tuscaloosa
+0.7142235159476539,103.8,"501 Santiago Park Ln, Kingsville, TX 78363",Dick Kleberg Park,"1000 Sports Park Blvd, Brownsville, TX 78526",Brownsville Sports Park
+0.7151424963924965,5.7,"5521 Lincoln Hwy 1a, Crown Point, IN 46307",Midwest Express Clinic Crown Point,"1201 South Main Street Crown Point, IN 46307",Franciscan Health Crown Point
+0.7153371320037986,27.9,"200 Memorial Ave, Westminster, MD 21157",Carroll Hospital,"1800 Orleans St, Baltimore, MD 21287",Johns Hopkins Hospital
+0.715619610741562,6.9,"2211 Lomas Blvd NE, Albuquerque, NM 87106",UNMH Respiratory Care Center,"13701 Encantado Rd. NE Albuquerque, NM 87123",OPTUM
+0.7162162162162162,373.3,"1306 W Stevens St, Carlsbad, NM 88220",NMDOH SE Region - Carlsbad Public Health Office,"801 W Maple St, Farmington, NM 87401",San Juan Regional Medical Center
+0.7163041579315164,0.2,"1016 Roosevelt Ave, Grants, NM 87020",Cibola General Hospital,"700 E. Roosevelt, Suite 100, Grants, New Mexico 87020",Grants Public Health Office - Cibola County
+0.7166537966537966,37.6,"10350 Haligus Rd, Huntley, IL 60142",Northwestern Medicine Immediate Care Huntley,"2650 Ridge Avenue, Evanston, IL 60201",Evanston Hospital
+0.7167000381388253,21.0,"34515 9th Ave S, Federal Way, WA 98003",St. Francis Hospital,"720 8th Ave S, Seattle, WA 98104",International District Clinic
+0.7168394471026049,16.6,"229 Andover St, Peabody, MA 01960",CareWell Urgent Care-Peabody,"1290 Tremont Street ,Roxbury, MA 02120",Whittier Street Health Center
+0.7175802139037434,225.7,"2747 4th St, Brunswick, GA 31520",Glynn County Health Department,"727 54th Street Columbus, GA 31904",Cascade Hills Church
+0.7190651750148317,11.2,"235 S Gary Ave, Bloomingdale, IL 60108",Northwestern Medicine Immediate Care Bloomingdale,"137 W North Ave, Northlake, IL 60164",Walmart (Parking Lot)
+0.7196400091136933,21.2,"550 Peachtree St NE, Atlanta, GA 30308",Emory Hospital Midtown,4350 North Point Parkway Alpharetta GA 30022,North Point Community Church
+0.7199001339666302,1.8,"55 Lake Ave N., Worcester, MA 01604","UMass Medical Center, University Campus","123 Summer St, Worcester, MA 01608",St Vincent Hospital at Worcester Medical Center
+0.7204083115373437,0.6,"95 Leonard Ave 203, Washington, PA 15301",Central Outreach Wellness Center - Washington,"37 Highland Ave, Washington, PA 15301",Washington Family Doctors
+0.7222222222222222,41.8,"1 Cooper Plaza, Camden, NJ 08103",Cooper University Hospital,"215 Applegarth Road Monroe, NJ 08831",Hackensack Meridian Urgent Care - Monroe
+0.7226347226347226,8.1,"111 S 11th St, Philadelphia, PA 19107",Jefferson University Hospital - Center City,"7401 Ogontz Avenue, Philadelphia, PA 19138",Rite Aid Redi Clinic
+0.7230769230769231,148.1,"1801 E 51st St Bldg H, Austin, TX 78723",Austin Emergency Center Mueller,"5616 Lawndale St., Ste A108 Houston, TX 77023",Legacy Santa Clara
+0.7232563115104836,10.1,"4122 Market St, Philadelphia, PA 19104",University of Pennsylvania Health System - West Philadelphia,"7131 Frankford Ave Philadelphia, PA 19135",Einstein Healthcare Network testing Site
+0.7232804232804232,2.0,"13155 Noel Rd 2000, Dallas, TX 75240",Medical City Healthcare,"5917 Belt Line Rd, Dallas TX",Neighborhood Medical Center Clinic
+0.7233733733733733,37.5,"901 E Fifth St, Washington, MO 63090",Mercy Hospital Washington,"6900 Chippewa St, St. Louis, MO 63109",St. Louis Hills
+0.7236165577342049,5.8,"8201 Golf Course Rd NW, Albuquerque, NM 87120",Next Care Urgent Care - Petroglyph,"5150 Journal Center Blvd. SE Albuquerque, NM 87109",OPTUM
+0.7236323279801541,49.3,"50 Worcester Rd, Framingham, MA 01702",CareWell Urgent Care-Framingham,"40 Wright St, Palmer, MA 01069",Baystate Wing Hospital
+0.7239626723497691,0.5,"1600 E 32nd St, Silver City, NM 88061",Silver City Health Care Clinic,"2610 N. Silver, Silver City, New Mexico 88061",Grant County Public Health Office
+0.7240259740259741,5.3,"3563 Far W Blvd, Austin, TX 78731",Austin Emergency Center Far West,"12319 N Mopac Expy, Austin, TX 78758",Texas MedClinic
+0.7243083003952568,8.3,"1218 Trotwood Ave Bldg C, Columbia, TN 38401",Maury Regional Urgent Care Columbia,"2478 Nashville Hwy Suite A, Columbia, TN 38401",Maury Regional Urgent Care North Columbia
+0.7244152046783626,18.7,"30809 1st Ave S, Federal Way, WA 98003",Franciscan Medical Clinic,"720 8th Ave S, Seattle, WA 98104",International District Clinic
+0.7245234708392604,259.1,"201 N Mayfair Rd, Wauwatosa, WI 53226",Ascension Wisconsin Urgent Care at Mayfair Road,"13380 W Trepania Rd, Hayward, WI 54843",Lac Courte Oreilles Community Health Center
+0.7254960317460318,10.3,"6959 Forest Preserve Dr, Chicago, IL 60634",Illinois National Guard Mobile Testing Site,"259 E Erie St, Chicago, IL 60611",Northwestern Medicine Lavin Family Pavilion
+0.7257044419835118,21.4,"520 S Maple Ave, Oak Park, IL 60304",Rush Oak Park Hospital,"777 Park Ave. West, Highland Park, IL 60035",Highland Park Hospital
+0.7263427109974425,12.8,"1 College Dr, Toms River, NJ 08753",Ocean County College,"701 U.S. 9, Forked River, NJ 08731",Hackensack Meridian Urgent Care-Forked River
+0.7267284816373175,2.7,"3330 Siskey Pkwy, Matthews, NC 28105",Novant McKee Medical,"630 Matthews Township Pkwy, Matthews, NC 28105",Tryon Satellite Location Matthews
+0.7268705952916479,85.6,"468 Cadieux Rd, Grosse Pointe, MI 48230","Beaumont Health, Grosse Pointe","804 Service Rd, East Lansing, MI 48824",Michigan State University
+0.7272676205942131,2.5,"910 Old Camp Rd 130, The Villages, FL 32162",Premier Medical Associates,"703 N Buena Vista Blvd, The Villages, FL 32162",The Villages Polo Club
+0.7281792281792283,7.2,"3401 SE 10th Ave, Amarillo, TX 79104",City of Amarillo/Texas Tech University Health Sciences Center,"7304 SW 34th, Amarillo, TX",BSA CareXpress Urgent Care
+0.72819205883722,7.7,"10050 Roosevelt Blvd, Philadelphia, PA 19116",Tower Health Urgent Care,"7401 Ogontz Avenue, Philadelphia, PA 19138",Rite Aid Redi Clinic
+0.7283500717360115,31.1,"327 Medical Park Dr, Bridgeport, WV 26330",United Hospital Center,"207 S Price St, Kingwood, WV 26537",Kingwood Elementary School
+0.7291412291412293,7.9,"51 N 39th St, Philadelphia, PA 19104",Penn Presbyterian Medical Center,"7401 Ogontz Avenue, Philadelphia, PA 19138",Rite Aid Redi Clinic
+0.7300000000000001,33.0,"2125 NJ-88, Brick Township, NJ 08724",Hackensack Meridian Urgent Care - Brick,"2421 US-1, North Brunswick Township, NJ 08902",PM Pediatrics
+0.7304504504504504,22.5,"1080 Stelton Rd, Piscataway, NJ 08854",Hackensack Meridian Urgent Care - Piscataway,"2100 Wescott Dr, Flemington, NJ 08822",Hunterdon Medical Center
+0.7307797270955166,20.2,"18101 Preston Rd 201, Dallas, TX 75252",Sinai Urgent Care,"3201 W. Saner Ave., Dallas, TX 75233",MD Kids Pediatrics - Saner Location
+0.7307954545454546,22.0,"7495 State St, Midvale, UT 84047",Greenwood Health Center,"777 N Main St Tooele, UT 84074",Tooele InstaCare
+0.7308287687544652,62.0,"1037 NY-109, Farmingdale, NY 11735",AFC Urgent Care Farmingdale,"1500 NY-9D, Wappingers Falls, NY 12590",Intermodal Center at Dutchess Stadium
+0.7316299929303641,3.6,"50 N Medical Dr, Salt Lake City, UT 84132",University of Utah Hospital,"1280 E Stringham Ave, Salt Lake City, UT 84106",Sugar House Health Center
+0.7318166219504587,4.6,"1500 Forest Glen Rd, Silver Spring, MD 20910",Holy Cross Hospital,"13428 New Hampshire Ave Silver Spring, MD 20904",Silver Spring Fast Track Urgent Care
+0.7319613135402608,103.7,"1500 Division St, Oregon City, OR 97045",Providence Willamette Memorial Hospital,"13000 SW Century Drive, Bend, OR 97702",Summit Medical Group - Mt. Bachelor
+0.7323436797121007,1.3,"333 Borthwick Ave, Portsmouth, NH 03801",Portsmouth Regional Hospital,"599 Lafayette Rd, Portsmouth, NH 03801",Convenient MD Urgent Care
+0.732404181184669,1.6,"2905 3rd Ave SE, Aberdeen, SD 57401",Sanford Aberdeen Medical Center,"305 South State Street Aberdeen, SD 57401",Avera St. Luke’s Hospital
+0.7335880398671096,9.6,"101 E Olney Ave C5, Philadelphia, PA 19120",Einstein Physicians Olney,"1 Citizens Bank Way, Philadelphia, PA 19148",Citizens Bank Park
+0.7341269841269841,1.6,"800 Clematis St, West Palm Beach, FL 33401",West Palm Beach-Health Department Main Office,"2606 S Dixie Hwy., West Palm Beach, FL 33401",MD Now Urgent Care
+0.7342555994729908,145.7,"643 5th St, Fort Sumner, NM 88119",Ft. Sumner Public Health Department,"356 9th St, Cimarron, NM 87714",Cimarron Healthcare Clinic
+0.7343603766367993,2.9,"120 Craig Rd, Freehold Township, NJ 07728",The Doctors' Office Urgent Care of Manalapan,"315 W. Main Street Freehold, NJ 07728",Hackensack Meridian Urgent Care - Freehold
+0.7347347176136557,3.0,"800 E Carpenter St, Springfield, IL 62769",HSHS St. John’s,"2950 South Sixth Street, Springfield, IL 62703",Respiratory Clinic at Memorial Physician Services - South Sixth
+0.7349769585253456,148.8,"251 N 4th St, Oakland, MD 21550",Garrett Regional Medical Center,"22 S Greene St, Baltimore, MD 21201",University of Maryland Medical System
+0.7354464285714286,89.4,"3635 Market St, Hoover, AL 35226",Ross Bridge Medical Center,"320 Main St, Roanoke, AL 36274",Randolph County Health Department
+0.7358220211161388,0.1,"24 Hospital Ave, Danbury, CT 06810",Danbury Hospital,"95 Loucust Ave, Danbury CT",Danbury Hospital
+0.7360269360269361,225.0,"35 Clayton Rd, Arden, NC 28704","Biltmore Church - Arden Campus: 35 Clayton Rd, Arden","111 Sunnybrook Rd, Raleigh, NC 27610",UNC Hospitals at WakeBrook
+0.7364182364182364,2.2,"5755 Cedar Ln, Columbia, MD 21044",Howard County General Hospital,"6340 Woodside Ct, Columbia, MD, 21046",VEIP converted to COVID TESTING SITE
+0.7365266106442577,37.3,"1210 Provident Dr, Warsaw, IN 46580",Lutheran Health System,"700 Broadway, Fort Wayne, IN 46802",St. Josesphs Hospital
+0.7365266106442577,14.8,"6150 E Broad St, Columbus, OH 43213",Mount Carmel Corporate Service Center,"4760 Sawmill Rd, Columbus OH 43235",Scioto Urgent Care
+0.7366452991452991,40.4,"2900 Foxfield Dr, St. Charles, IL 60174",Northwestern Medicine Immediate Care St. Charles,"900 N 2nd St, Rochelle, IL 61068",Rochelle Community Hospital
+0.736842105263158,276.0,"501 N Glendale Ave, Glendale, CA 91206",Glendale Public Health Center,"550 South Green Valley Road, Watsonville, CA 95076",Sutter Health - Watsonville Center Urgent Care
+0.7371040723981899,52.0,"20 S Plum St, Vermillion, SD 57069",Sanford Vermillion Medical Center,"2100 S Marion Rd, Sioux Falls, SD 57106",Avera Medical Group Family Health Center - Sioux Falls
+0.7376232917409388,171.3,"20 Hartford St, Houlton, ME 04730",Houlton Regional Hospital,"420 Franklin St, Rumford, ME 04276",Rumford Hospital - Satellite Testing Site - Central Maine Healthcare
+0.737718498252014,24.6,"16520 S Westland Dr, Gaithersburg, MD 20877",MDOT MVA Vehicle Inspection/Emission Center: Walnut Hill,"10251 Central Ave, Largo, MD 20774",Motor Vehicle Administration
+0.7378147526414537,63.8,"1125 Madison St, Jefferson City, MO 65101",Capital Region Medical Center,"1717 Madison Ave, Washington, MO 63090",Washington
+0.7383040935672515,2.5,"750 S Park Ave, Pomona, CA 91766",Pomona Public Health Center,"1101 W. McKinley Ave, Pomona, CA 91768",Los Angeles County Fairplex
+0.7384254443751012,5.7,"506 Malcolm X Blvd, New York, NY 10037",NYC Health + Hospitals/Harlem,"225 W 23rd St, New York, NY 10011",GoHealth Urgent Care Center - Chelsea
+0.7388278388278389,87.6,"9449 Friars Rd, San Diego, CA 92108",SDCCU Stadium,"4300 Rose Dr, Yorba Linda, CA 92886",St. Joseph Heritage Medical Center
+0.7389047619047618,116.8,"12500 Willowbrook Rd, Cumberland, MD 21502",UPMC Western Maryland,"1800 Orleans St, Baltimore, MD 21287",Johns Hopkins Hospital
+0.7393406593406594,2.6,"300 Pasteur Dr, Palo Alto, CA 94304",Stanford Medical Center,"3250 Alpine Road, Portola Valley, CA 94028",Stanford Primary Care in Portola Valley
+0.7398780487804878,39.4,"15910 Chieftain Ave, Rockville, MD 20855",MDOT MVA Vehicle Inspection/Emission Center: Derwood,"11760 Baltimore Ave, Beltsville, MD 20705",Beltsville Vehicle Emissions Inspection Program (VEIP) station
+0.7408708560118753,7.9,"2110 Sunset Blvd Suite M, Los Angeles, CA 90026",Carbon Health,"2040 Camfield Avenue, Los Angeles, Ca 90040",Altamed Medical Group
+0.741,183.5,"1127 Bruce B Downs Blvd, Wesley Chapel, FL 33544",AdventHealth-Centra Care Wesley Chapel,"1425 South Congress Avenue, Delray Beach, FL 33445",Dr. G's Urgent Care
+0.74160724896019,26.5,"5 Garrett Ave, La Plata, MD 20646",University of Maryland Charles Regional Medical Center,"10251 Central Ave, Largo, MD 20774",Motor Vehicle Administration
+0.7419799498746869,29.7,"193 NY-59, Nanuet, NY 10954",Medrite Urgent Care,"1500 NY-9D, Wappingers Falls, NY 12590",Intermodal Center at Dutchess Stadium
+0.7427751460009525,80.9,"745 Poplar Rd, Newnan, GA 30265",Piedmont Newnan,"2395 Thompson Rd, Dawsonville, GA 30534",Chestatee Emergent Medical Care
+0.7429361179361179,118.9,"1001 Providence Dr, Newberg, OR 97132",Providence Newberg Memorial Hospital,"1501 NE Medical Center Drive, Bend, OR 97701",Summit Medical Group - Eastside
+0.7429666119321291,41.9,"580 Court St, Keene, NH 03431",Cheshire Medical Center,"1059 Canal St, Manchester, NH 03101",National Guard State Armory
+0.7449199922884132,13.9,"330 W Maple Ave, Monrovia, CA 91016",Monrovia Public Health Center,"1101 W. McKinley Ave, Pomona, CA 91768",Los Angeles County Fairplex
+0.7455706521739132,1.1,"1631 Elysian Fields Ave, New Orleans, LA 70117",Crescent Care,"1419 Basin Street, New Orleans, LA 70116",Mahalia Jackson Theater Parking Lot
+0.7461538461538462,4.0,"5205 Melrose Ave, Los Angeles, CA 90038",Hollywood/Wilshire Public Health Center,"8730 Alden Drive, Los Angeles, CA 90059",Cedars-Sinai Medical Center
+0.74618312963334,82.8,"3318 N Northhills Blvd, Fayetteville, AR 72703",Washington Regional COVID-19 Screening Clinic,"358 East Valley Street Yellville, AR 72687","Boston Mountain Rural Health Systems, Inc."
+0.7464214046822744,40.5,"7201 N University Dr, Tamarac, FL 33321",University Hospital and Medical Center,"7305 N Military Trl, West Palm Beach, FL 33410",West Palm Beach VA Medical Center
+0.7467082467082468,0.6,"200 Ocean 36th St, Marathon, FL 33050",Marathon Community Park,"2805 Overseas HWY Marathon, FL 33050",Community Health of South Florida - Marathon
+0.7471713471713471,4.7,"401 N Ewing St, Lancaster, OH 43130",Fairfield Medical Center Main Campus - Emergency Department,"2384 N Memorial Dr, Lancaster, OH 43130",Fairfield Medical Center - River Valley Campus
+0.7474358974358973,48.2,"190 Blue Devil Ln, Gainesboro, TN 38562",Jackson County Health Department at Jackson County High School,"1503 S Main St, Crossville, TN 38555",Cumberland County Health Department
+0.7475708502024291,299.1,"1940 N Monroe St, Tallahassee, FL 32303",Tallahassee Memorial HealthCare,"1410 Sports Blvd, Cape Coral, FL 33991",Cape Coral Sports Complex
+0.7483787593984963,23.4,"1400 Cambridge St, Cambridge, MA 02138",CareWell Urgent Care-Cambridge Inman Square,"1 General St, Lawrence, MA 01841",Lawrence General Hospital
+0.7486166007905138,11.1,"15740 S Outer Forty Rd, Chesterfield, MO 63017",Mercy Hospital,"12409 St. Charles Rock Rd, Bridgeton, MO 63044",Bridgeton
+0.7490970499035016,0.8,"241 N Figueroa St, Los Angeles, CA 90012",Central Public Health Center,"1700 Stadium Way, Los Angeles, CA 90012",Hotchkins Memorial Training Center
+0.7492737835875091,0.2,"1945 NJ-33, Neptune City, NJ 07753",Jersey Shore University Medical Center / K. Hovnanian Children's Hospital,"2040 Route 33 Neptune City, NJ 07753",Hackensack Meridian Urgent Care - Neptune City
+0.7502764127764129,52.0,"1900 Washington St, Grafton, WI 53024",Grafton High School,"10400 75th St., Kenosha, WI 53142",Aurora Medical Center Kenosha
+0.7503232644409116,9.9,"700 Children's Dr, Columbus, OH 43205",Nationwide Children's Hospital,"4760 Sawmill Rd, Columbus OH 43235",Scioto Urgent Care
+0.7506734006734007,325.2,"1513 W Fir St, Portales, NM 88130",NMDOH SE Region - Portales Public Health Office,"801 W Maple St, Farmington, NM 87401",San Juan Regional Medical Center
+0.7510850439882697,7.1,"825 S 169th St, Omaha, NE 68118",Nebraska Methodist Health System,"8303 Dodge St, Omaha, NE 68118",Methodist Hospital
+0.7516769073220685,0.7,"5126 Hospital Dr NE, Covington, GA 30014",Piedmont Newton,"8203 Hazelbrand Rd NE, Covington, GA 30014",Newton County Health Dept
+0.7521520803443328,0.7,"99 Matthew Dr, Uniontown, PA 15401",Uniontown Hospital Drive-Thru Site,"86 McClellandtown Rd, Uniontown, PA 15401",Uniontown Family Doctors
+0.7532442216652743,79.6,"725 S Wahanna Rd, Seaside, OR 97138",Providence Seaside Memorial Hospital,"525 SE Washington St, Dallas, OR 97338",Salem Health West Valley Hospital
+0.7547058823529411,0.0,"3905 OK-97, Sand Springs, OK 74063",Access Solutions Medical Group - Sand Springs,"3090 State Highway 97, Sand Springs, OK 74063",Access Solutions Medical Group-Sand Springs
+0.7548627058430979,3.5,"348 Greenwood St, Worcester, MA 01607",CareWell Urgent Care-Worcester Greenwood St,"123 Summer St, Worcester, MA 01608",St Vincent Hospital at Worcester Medical Center
+0.7550407422827573,3.3,"3401 Civic Center Blvd, Philadelphia, PA 19104",Children's Hospital of Philadelphia,"1 Citizens Bank Way, Philadelphia, PA 19148",Citizens Bank Park
+0.7553282182438193,63.6,"22 Bramhall St, Portland, ME 04102",Maine Medical Center,"420 Franklin St, Rumford, ME 04276",Rumford Hospital - Satellite Testing Site - Central Maine Healthcare
+0.7557060755336618,35.7,"19801 Observation Dr, Germantown, MD 20876",Holy Cross Germantown Hospital Emergency Room,"1800 Orleans St, Baltimore, MD 21287",Johns Hopkins Hospital
+0.7560115638665764,71.8,"100 Hospital Rd, Prince Frederick, MD 20678",CalvertHealth Medical Center,"1601 Bowmans Farm Rd, Frederick, MD 21701",Vehicle Emissions Inspection Program (VEIP) station
+0.7564386256069827,111.5,"55 Fruit St, Boston, MA 02114",Massachusetts General Hospital,"725 North St, Pittsfield, MA 01201",Berkshire Medical Center
+0.7572475226649799,6.6,"510 Boston Rd, Billerica, MA 01821",CareWell Urgent Care- Billerica,"1 Hospital Dr, Lowell, MA 01852",Lowell General Hospital
+0.7572727272727273,2.1,"13435 US-183, Austin, TX 78750",Austin Emergency Center Anderson Mill,"14016 N, US-183, Austin, TX 78717",St. David's Emergency Center - Cedar Park
+0.7580519480519481,100.9,"2950 Cleveland Clinic Blvd, Weston, FL 33331",Cleveland Clinic Florida,"2776 Cleveland Ave, Fort Myers, FL 33901",Lee Memorial Hospital
+0.7582022311212815,0.5,"1800 NW Myhre Rd, Silverdale, WA 98383",Harrison Medical Center,"10452 Silverdale Way N.W. Silverdale, WA 98383",Silverdale: Kaiser Permanente Silverdale Medical Center
+0.758617153739105,0.9,"1301 W 18th St, Sioux Falls, SD 57104",Sanford Heart Hospital,"2501 W. 22nd Street Sioux Falls, SD 57105",Royal C. Johnson Veterans Memorial Hospital
+0.7587352302869544,118.1,"1717 S Calhoun St, Fort Wayne, IN 46802",Neighborhood Health Clinic,"1201 South Main Street Crown Point, IN 46307",Franciscan Health Crown Point
+0.758751937984496,35.4,"2604 Schoenersville Rd, Bethlehem, PA 18017",LVHN COVID-19 Assess and Test–Muhlenberg,"2500 Bernville Rd, Reading, PA 19605",Penn State Health St. Joseph Medical Center
+0.7592126623376623,134.3,"214 E 23rd St, Cheyenne, WY 82001",Cheyenne Regional Medical Center,"2221 W Elm St, Rawlins, WY 82301",Memorial Hospital of Carbon County
+0.7597772597772597,41.7,"1412 Milstead Ave, Conyers, GA 30012",Piedmont Rockdale,"410 McKinley Dr, Athens, GA 30601",Clarke County Health Department
+0.7602182539682539,2.9,"2315 Stockton Blvd, Sacramento, CA 95817",UC Davis Medical Center,"1600 Exposition Blvd, Sacramento, CA 95815",Sacramento Mobile COVID-19 Testing Site
+0.7611179670003199,54.3,"1255 GA-54, Fayetteville, GA 30214",Piedmont Fayette,"5450 GA-20 Cartersville, GA 30121",Clarence Brown Conference Center
+0.7613431013431012,25.5,"1300 Crane St, Menlo Park, CA 94025",Menlo Medical Clinic,"1998 Market St, San Francisco, CA 94102",Carbon Health - SF Castro
+0.7627659574468085,249.3,"11190 Health Park Blvd, Naples, FL 34110",NCH Healthcare System,"400 Health Park Blvd, Saint Augustine, FL 32086",Flagler Health+
+0.7636579371133145,195.8,"215 Lancaster Ave, Malvern, PA 19355",Tower Health Urgent Care,"2128 Oakland Avenue, Indiana, PA 15701",MedExpress
+0.7640568422490946,5.2,"800 Carter St, Rochester, NY 14621",Wilson Center Urgent Care - Rochester General Hospital,"150 Crittenden Blvd., Rochester, NY 14642",Golisano Children's Hospital
+0.764494126563092,83.4,"275 Pine Rd, Newnan, GA 30263",Coweta County Fair Grounds,"2395 Thompson Rd, Dawsonville, GA 30534",Chestatee Emergent Medical Care
+0.7654441533698498,144.4,"1 Medical Park, Wheeling, WV 26003",Wheeling Hospital,"176 Medical Center, Rainelle, WV 25962",Rainelle Medical Center
+0.7676211926211927,8.5,"30 Prospect Ave, Hackensack, NJ 07601",Hackensack University Medical Center - Emergency Room / Joseph M. Sanzari Children's Hospital,"300 Pompton Road Wayne, NJ 07470",William Paterson University
+0.768430369787569,4.7,"7401 Jefferson Ave, Hyattsville, MD 20785",MDOT MVA Vehicle Inspection/Emission Center: Hyattsville,"6401 America Blvd, Hyattsville, MD 20782",MedStar Health Urgent Care
+0.768918918918919,1.1,"1729 Benson Ave, Evanston, IL 60201",NorthShore University HealthSystem,"2650 Ridge Avenue, Evanston, IL 60201",Evanston Hospital
+0.7696852689793867,31.6,"13755 S Main St, Houston, TX 77035",Butler Stadium,"136 E Hospital Dr., Angleton TX,  77515",UTMB Health Access Center
+0.770045280390108,0.5,"8 Pikes Hill, Norway, ME 04268",Western Maine Health,"181 Main St, Norway, ME 04268",Stephens Memorial Hospital
+0.7705471124620061,2.8,"12335 Georgia Ave, Silver Spring, MD 20906",MDOT MVA Vehicle Inspection/Emission Center: Glenmont,"13428 New Hampshire Ave Silver Spring, MD 20904",Silver Spring Fast Track Urgent Care
+0.7705637657361795,4.2,"321 Middlefield Rd, Menlo Park, CA 94025",Menlo Medical Clinic,"3250 Alpine Road, Portola Valley, CA 94028",Stanford Primary Care in Portola Valley
+0.7716758111494952,116.1,"9205 SW Barnes Rd, Portland, OR 97225",Providence St. Vincent Memorial Hospital,"865 SW Veterans Way, Redmond, OR 97756",Summit Medical Group - Redmond Clinic
+0.77275,0.5,"2635 Church Rd, Aurora, IL 60502",Northwestern Medicine Immediate Care Aurora,"2853 Kirk Road  Aurora, IL 60502",Urgent Care Aurora
+0.7730407523510973,210.5,"1266 GA-515, Jasper, GA 30143",Piedmont Mountainside,"16942 GA-67, Statesboro, GA 30458",Ogeechee Fairgrounds
+0.7736564996368918,47.5,"50 Hospital Dr, Hendersonville, NC 28792",AdventHealth,"1 Hospital Rd., Cherokee, NC 28719",Cherokee Indian Hospital
+0.7765512265512265,2.8,"186 Paradise Blvd, Athens, GA 30607",Athens Environmental Health Service,"410 McKinley Dr, Athens, GA 30601",Clarke County Health Department
+0.7779761904761905,0.8,"11890 Healing Way, Silver Spring, MD 20904",Adventist HealthCare White Oak Medical Center,"2121 Industrial Parkway, Silver Spring, MD 20904",VEIP converted to COVID TESTING SITE - Silver Spring
+0.7802894779638967,13.2,"11833 Wilmington Ave, Los Angeles, CA 90059","Martin Luther King, Jr. Center for Public Health","8730 Alden Drive, Los Angeles, CA 90059",Cedars-Sinai Medical Center
+0.7830065359477124,6.8,"7525 Tidwell Rd, Houston, TX 77016",Northeast Houston at Forest Brook Middle School,"510 W Tidwell Rd, Houston, TX, 77091",United Memorial Medical Center - Tidwell
+0.7864285714285714,2.9,"201 E University Pkwy, Baltimore, MD 21218",MedStar Union Memorial Hospital,"22 S Greene St, Baltimore, MD 21201",University of Maryland Medical System
+0.7872722995227533,0.8,"355 S Miller Ave, Farmington, NM 87401",NMDOH NW Region - Farmington Public Health Office,"801 W Maple St, Farmington, NM 87401",San Juan Regional Medical Center
+0.7875,35.4,"111 Grossman Dr, Braintree, MA 02184",Atrius Health: Braintree Site,"1 General St, Lawrence, MA 01841",Lawrence General Hospital
+0.7877177700348432,0.8,"1 Medical Center Dr, Morgantown, WV 26505",J.W. Ruby Memorial Hospital,"1200 JD Anderson Dr., Morgantown, WV 26505",Mon Health Medical Center
+0.7884065610997343,7.0,"3000 N Fourth St, Flagstaff, AZ 86004",Coconino Community College Fourth Street Campus,"2446 Fort Tuthill Loop, Flagstaff, AZ 86004",The Coconino County Department of Health and Human Services drive-up coronavirus swab testing
+0.7888975932454194,0.1,"3 Truman Parkway, Annapolis, MD 21401",Anne Arundel County Department of Health,"1 Harry S. Truman Parkway, Annapolis, MD 21401",Anne Arundel County Department of Health’s free drive-through COVID-19
+0.788988416988417,4.2,"5504 Menaul Blvd NE, Albuquerque, NM 87110",Next Care Urgent Care - Menaul,"5150 Journal Center Blvd. SE Albuquerque, NM 87109",OPTUM
+0.7892255892255893,0.1,"1901 Redrock Dr, Gallup, NM 87301",Rehoboth McKinley Christian Healthcare Services,"1919 College Drive, Gallup, New Mexico 87301",Gallup Public Health Office - McKinley County
+0.7896477272727273,4.8,"2285 Sequoia Dr, Aurora, IL 60506",Advocate Medical Group Outpatient Center,"2853 Kirk Road  Aurora, IL 60502",Urgent Care Aurora
+0.7901400679117148,13.8,"5841 S Maryland Ave, Chicago, IL 60637",University of Chicago Medical Center,"5140 N California Ave, Chicago, IL 60625",Swedish Hospital
+0.7908496732026143,14.6,"3258 W 111th St, Chicago, IL 60655",Midwest Express Clinic Chicago - Mt. Greenwood,"259 E Erie St, Chicago, IL 60611",Northwestern Medicine Lavin Family Pavilion
+0.7923989898989899,0.6,"124 Daniel Dr, Danville, KY 40422",Integrity Extended Healthcare,"1591 Hustonville Rd., Danville, KY 40422",First Care Urgent Care- Danville
+0.7924731182795699,3.3,"4350 Dewey Ave, Omaha, NE 68105",Nebraska Medicine,"8303 Dodge St, Omaha, NE 68118",Methodist Hospital
+0.7928704566635602,95.4,"4805 NE Glisan St, Portland, OR 97213",Providence Portland Memorial Hospital,"470 NE A St, Madras, OR 97741",St. Charles - Madras
+0.7943965517241379,96.2,"45 W 111th St, Chicago, IL 60628",Roseland Hospital,"403 E 1st St, Dixon, IL 61021",KSB Hospital
+0.7955128205128206,163.0,"2108 E Hill Ave, Valdosta, GA 31601",Lowndes County Civic Center,"210 Forest Hill Drive Hamilton, GA 31811",Harris County Health Department
+0.7975314630662679,6.9,"2451 Grant Ave, Philadelphia, PA 19114",Jefferson Health - Roosevelt Boulevard,"7401 Ogontz Avenue, Philadelphia, PA 19138",Rite Aid Redi Clinic
+0.7984508899143045,0.8,"1305 W 18th St, Sioux Falls, SD 57105",Sanford USD Medical Center,"2501 W. 22nd Street Sioux Falls, SD 57105",Royal C. Johnson Veterans Memorial Hospital
+0.7986679986679988,0.4,"16251 Sylvester Rd SW, Burien, WA 98166",Highline Medical Center,"16045 1st Ave S, Burien, WA 98148",Franciscan Prompt Care – Burien
+0.798840579710145,13.0,"3201 E Houston St, San Antonio, TX 78219",South Texas Medical Center,"323 North Loop 1604 West San Antonio, TX 78232",Texas MedClinic - Loop 1604 / Stone Oak Pkwy
+0.7999999999999999,0.2,"900 23rd St NW, Washington, DC 20037",George Washington University Hospital,"800 21st St NW, Washington, DC 20052",George Washington University(Foggy Bottom campus)
+0.8007612648053246,0.9,"2055 Oakdale Rd, Coralville, IA 52241",Mercy Family Medicine-Coralville,"2490 Crosspark Road, Coralville, IA 52241",State Hygenic Laboratory at the University of Iowa
+0.8037380882208468,1.4,"2804 Birch St, Parkersburg, WV 26101",Camden Clark Health and Wellness Center,"800 Garfield Ave, Parkersburg, WV 26101",Camden Clark Medical Center
+0.8037878787878788,2.7,"2861 Broad Ave, Memphis, TN 38112",Christ Community Health Services Broad Avenue Health Center,"2569 Douglass Ave, Memphis, TN 38114",Christ Community Health Services Orange Mound Health Center
+0.804055944055944,0.8,"136 Lake St, Ephrata, PA 17522",WellSpan Family Medicine - Lake Street,"169 Martin Ave, Ephrata, PA 17522",WellSpan Ephrata Community Hospital
+0.8042857142857143,74.8,"42 Washington St, Norwell, MA 02061",CareWell Urgent Care-Norwell,"40 Wright St, Palmer, MA 01069",Baystate Wing Hospital
+0.8052151416122003,1.2,"2100 Comer Ave, Columbus, GA 31904",Columbus Health Department,"3702 2nd Ave, Columbus, GA 31904",MercyMed of Columbus
+0.8067246970472777,0.2,"564 South Ave, New Canaan, CT 06840",Murphy Medical Associates,"468 South Avenue, New Canaan CT",Drive Thru Coronovirus Testing Facility New Canaan
+0.8082565789473684,0.9,"1900 Gravier St, New Orleans, LA 70112",Oschner- LSU Health Shreveport,"1419 Basin Street, New Orleans, LA 70116",Mahalia Jackson Theater Parking Lot
+0.810974025974026,6.3,"710 Center St, Columbus, GA 31901",Piedmont Columbus Regional - Midtown,"7901 Veterans Parkway Columbus, GA 31909",ACE Healthcare Center
+0.8123935349741801,1.8,"1 Shircliff Way, Jacksonville, FL 32204",St. Vincent's Hospital,"1000 Water St, Jacksonville, FL 32204",Prime F. Osborn III Convention Center
+0.8160067873303167,0.6,"1805 27th St, Portsmouth, OH 45662",Southern Ohio Medical Center,"1202 18 th Street, Portsmouth, OH 45662",SOMC Friends Community Center
+0.8161094158674804,3.5,"200 N Michigan Ave, Chicago, IL 60601",Forward Clinic,"2400 N Ashland Avenue, Chicago, IL 60614",Innovative Express Care
+0.8169091292430951,108.5,"100 Dutton St, Bangor, ME 04401",Bass Park in Bangor,"10 Hospital Dr, Bridgton, ME 04009",Bridgton Hospital
+0.8177777777777778,1.9,"1400 Teche St, New Orleans, LA 70114",Common Ground Health Clinic - Algiers,"1419 Basin Street, New Orleans, LA 70116",Mahalia Jackson Theater Parking Lot
+0.8182432432432434,0.5,"12 St Paul Dr, Chambersburg, PA 17201",WellSpan Health Campus,"1000 Norland Ave, Chambersburg, PA 17201",Chambersburg Urgent Care
+0.8215883371055785,50.3,"145 W University Pkwy, Orem, UT 84058",Parkway Health Center,"165 N University Ave, Farmington, UT 84025",Farmington Health Center
+0.8239018087855298,45.8,"123 W Manchester Blvd, Inglewood, CA 90301",Curtis R. Tucker Public Health Center,"1233 Rancho Vista Blvd., Palmdale, CA 93551",Antelope Valley Mall Testing Site
+0.8247354497354497,0.8,"411 Grand Ave, Oakland, CA 94610",Carbon Health,"3850 Grand Avenue  Oakland, CA 94610",One Medical
+0.8249019607843138,148.4,"4014 S Lamar Blvd, Austin, TX 78704",Austin Emergency Center South Lamar,"401 Branard St., Houston, TX 77006",Legacy Branard
+0.825219421101774,2.0,"1 Elliot Way, Manchester, NH 03103",Elliot Hospital,"1059 Canal St, Manchester, NH 03101",National Guard State Armory
+0.8257888657888658,26.0,"273 Teaticket Hwy, Falmouth, MA 02536",Cape Cod Healthcare Urgent Care - Falmouth,"275 Sandwich Street, Plymouth, MA 02360",Beth Israel Deaconess Hospital Plymouth
+0.8263814616755794,16.5,"128 W 14th St, Hazleton, PA 18201",LVHN COVID-19 Assess and Test–14th Street,"128 E Main St, Nanticoke, PA 18634",Geisinger Nanticoke
+0.8289972899728998,2.3,"4900 Frankford Ave, Philadelphia, PA 19124",Jefferson Frankford Hospital,"7131 Frankford Ave Philadelphia, PA 19135",Einstein Healthcare Network testing Site
+0.8294067093409199,2.8,"915 N Grand Blvd, St. Louis, MO 63106",VA St. Louis Health Care System,"3114 S Grand Blvd, St. Louis, MO 63118",Tower Grove
+0.8319917582417582,1.6,"1901 1st Avenue, New York, NY 10029",NYC Health + Hospitals/Metropolitan,"1150 3rd Ave, New York, NY 10065",East 67th Urgent Care
+0.8332917156286722,17.6,"401 NW 42nd Ave, Plantation, FL 33317",Plantation General Hospital,"401 E 65th ST, Hialeah, FL 33013",Amelia Earhart Park
+0.8376310313182623,0.7,"1600 W 22nd St, Sioux Falls, SD 57105",Sanford Children’s Hospital Sioux Falls,"2501 W. 22nd Street Sioux Falls, SD 57105",Royal C. Johnson Veterans Memorial Hospital
+0.8377142857142857,43.0,"500 Lincoln St, Worcester, MA 01605",CareWell Urgent Care-Worcester Lincoln St,"500 Lynnfield Street Lynn, MA 01904",North Shore Medical Union Hospital
+0.8377610693400167,0.2,"10101 S 27th St, Franklin, WI 53132",Ascension SE Wisconsin Hospital – Franklin Campus,"9969 South 27th St, Franklin, WI 53132",Ascension Medical Group - Franklin Medical Office Building - Primary & Specialty Care
+0.8380933062880325,0.0,"300 8th St, Estancia, NM 87016",Estancia Public Health Office,"300 South Eighth Street, Estancia, New Mexico 87016",Estancia Public Health Office - Torrance County
+0.8485380116959065,4.4,"10010 Kennerly Rd, St. Louis, MO 63128",Mercy Hospital South,"4400 Telegraph Rd, St. Louis, MO 63129",Oakville
+0.8513247592943988,0.6,"462 1st Avenue, New York, NY 10016",NYC Health + Hospitals/Bellevue,"561 3rd Ave, New York, NY 10016",East 37th Urgent Care
+0.851867816091954,0.0,"1812 S J St, Tacoma, WA 98405",Franciscan Prompt Care at St. Joseph,"1812 South J Street, Suite 120, Tacoma, WA 98405",Franciscan Prompt Care at St. Joseph
+0.8528769841269841,78.3,"1600 Divisadero St, SF, CA 94115",UC San Francisco,"1600 Exposition Blvd, Sacramento, CA 95815",Sacramento Mobile COVID-19 Testing Site
+0.8535788923719958,1.8,"2140 Mendon Rd, Cumberland, RI 02864",Ocean State Urgent Care of Cumberland,"2 Meehan Ln, Cumberland, RI 02864",Just Kids RI Sick Care
+0.8537151702786377,0.0,"750 Broadway 250, Fort Wayne, IN 46802",Fort Wayne Medical Education,"700 Broadway, Fort Wayne, IN 46802",St. Josesphs Hospital
+0.8556390977443609,12.4,"7211 N Interstate 35 Frontage Rd, Austin, TX 78752",Old Home Depot Lot,"7211 N. IH35 Frontage Road, Austin, TX",Home Depot (old location) Testing site
+0.8576190476190476,6.5,"56 Franklin St, Waterbury, CT 06706",Saint Mary's Hospital,"56 Franklin Street, Waterbury, Connecticut",Saint Mary's Hospital
+0.8590716581584421,0.0,"4700 Point Fosdick Dr, Gig Harbor, WA 98335",Franciscan Prompt Care,"4700 Pt. Fosdick Drive N.W., Suite 102, Gig Harbor, WA 98335",Franciscan Prompt Care - Gig Harbor
+0.8590959609827534,0.0,"700 Roosevelt Ave 100, Grants, NM 87020",NMDOH NW Region - Grants Public Health Office,"700 E. Roosevelt, Suite 100, Grants, New Mexico 87020",Grants Public Health Office - Cibola County
+0.8591446504159977,0.1,"7069 Hwy 70 S, Nashville, TN 37221",Vanderbilt Health Walk-In Clinic Bellevue,"7069 Highway 70 S, Bellevue, TN",Vanderbilt Health Walk-In Clinic Bellevue
+0.8591964285714284,42.1,"1 Medical Center Dr, Biddeford, ME 04005",Southern Maine Health Care: Emergency Room,"123 Medical Center Dr, Brunswick, ME 04011",Mid Coast Hospital
+0.8592709359605911,0.1,"700 UT-99, Fillmore, UT 84631",Fillmore Clinic,"700 S Highway 99 Fillmore, UT 84631",Fillmore Clinic
+0.8601876172607881,0.0,"2608 8th Ave S 102A, Berry Hill, TN 37204",Vanderbilt Health Walk-In Clinic Melrose,"2608 8th Ave S, Suite 102A, Melrose, TN","Vanderbilt Helath Walk-In Clinic, Melrose"
+0.8626192480359148,3.9,"2300 S 16th St, Lincoln, NE 68502",Bryan Medical Center,"555 S 70th St, Lincoln, NE 68510",CHI Health St Elizabeth
+0.865,2.1,"1201 NW 16th St, Miami, FL 33125",Miami VA Medical Center,"1350 NW 50 ST, Miami, FL 33142",Charles Hadley Park
+0.8689149015235972,0.0,"2536 TN-49 110, Pleasant View, TN 37146",NorthCrest Quick Care,"2536 Hwy 49, Suite 110 Pleasant View, TN 37146",NorthCrest Quick Care
+0.8690570475436197,0.1,"4911 Sandhill Dr, Sugar Land, TX 77479",The OakBend Medical Group,"4907 Sandhill Drive Sugar Land, Texas 77479",OakBend Medical Center New Territory Imaging Center
+0.8692161166093835,0.3,"9400 Universal Blvd, Orlando, FL 32819",FEMA/Nat'l Guard/FL Dept of Health (Orange County Convention Center),"9400 International Dr, Orlando, FL, 32819",Orange County Convention Center - North Concourse Parking Lot
+0.8702210070631123,0.0,"134 Pewitt Dr 200, Brentwood, TN 37027",Vanderbilt Health and Williamson Medical Center Walk-In Clinic Brentwood,"134 Pewitt Drive, Suite 200, Brentwood, TN",Vanderbilt Health & Williamson Medical Center Walk-In Clinic
+0.8717948717948718,0.0,"1485 US-40 Ste. G, Heber City, UT 84032",Heber InstaCare,"1485 S Highway 40 Ste G Heber, UT 84032",Heber InstaCare
+0.875383718337878,0.2,"400 W 7th St, Frederick, MD 21701",Frederick Health Hospital,"501 W. 7th Street, Frederick, MD 21701",Frederick Health Hospital
+0.8772351421188631,0.1,"1801 S Edwin C Moses Blvd, Dayton, OH 45417",University of Dayton Arena Parking Lot,"1801 Edwin C. Moses Blvd, Dayton, OH",Premier Health Mobile Testing - Univ of Dayton Arena Parking Lot
+0.8785706527642012,0.1,"4088 US-91, Hyde Park, UT 84318",North Cache Valley InstaCare,"4088 N HWY 91 Hyde Park, UT 84318",North Cache Valley InstaCare
+0.8810653293575496,0.2,"450 IL-22, Barrington, IL 60010",Advocate Good Shepherd Hospital,"450 W Hwy 22, Barrington, IL 60010",Advocate Good Shepherd Hospital
+0.8811301072152999,0.1,"2102 E Archer Rd, Baytown, TX 77521",Goose Creek ISD - Stallworth Stadium,"2102 East Archer Road, Baytown, TX",Goose Creek ISD – Stallworth Stadium Testing Site
+0.8826623376623377,0.0,"1834 W McEwen Dr 110, Franklin, TN 37067",Vanderbilt Health and Williamson Medical Center Walk-In Clinic Cool Springs,"1834 W McEwen Drive, Suite 110, Franklin, TN","Vanderbilt Health and Williamson County Walk-In Clinic, Cool Springs"
+0.883511586452763,0.1,"36245 US-27, Haines City, FL 33844",BayCare Urgent Care (Haines City),"36245 U.S. Highway 27, Haines City, FL 33844",BayCare Urgent Care (Haines City)
+0.8858730158730159,0.0,"2925 River Rd S 110, Salem, OR 97302",Salem Health Clinic,"2925 River Road S. Suite 110, Salem, Oregon 97302",Salem Health Medical Clinic - River Road S
+0.8859986772486772,3.9,"1000 Asylum Ave, Hartford, CT 06105",St. Francis Hospital,"1000 Asylum Street, Hartford, CT",Saint Francis Hospital
+0.8874684343434343,5.5,"3362 S 3rd St, Memphis, TN 38109",Christ Community Health Services Third Street Health Center,"364 S Front St, Memphis, TN 38103",901 Health and Wellness
+0.8881596452328159,0.0,"3120 Burnet Ave 406, Cincinnati, OH 45229","University of Cincinnati, Clifton Campus","3120 Burnet Ave, Cincinnati, Ohio",UC Health COVID-19 Drive-Thru Clinic
+0.8882882882882882,1.1,"3301 N Ashland Ave, Chicago, IL 60657",Midwest Express Clinic Chicago - Roscoe Village,"2400 N Ashland Avenue, Chicago, IL 60614",Innovative Express Care
+0.888414505587181,1.3,"227 Madison St, New York, NY 10002","NYC Health + Hospitals/Gotham Health, Gouverneur","24 Broad St, New York, NY 10005",Financial District Urgent Care
+0.8891278375149343,0.0,"714 10th St, Secaucus, NJ 07094",Riverside Medical Group,"714 Tenth St.Secaucus, NJ 07094",COVID-19 Command Center
+0.889693313222725,0.0,"701 U.S. 9, Lacey Township, NJ 08731",Hackensack Meridian Urgent Care - Forked River,"701 U.S. 9, Forked River, NJ 08731",Hackensack Meridian Urgent Care-Forked River
+0.8898039215686275,0.0,"2040 NJ-33, Neptune City, NJ 07753",Hackensack Meridian Urgent Care with Behavioral Health - Neptune City,"2040 Route 33 Neptune City, NJ 07753",Hackensack Meridian Urgent Care - Neptune City
+0.8917396745932415,0.0,"1071 MD-3 101, Gambrills, MD 21054",Chesapeake ERgent Care,"1071 MD-3 North, Suite 101, Gambrills, MD 21054",Chesapeake ERgent Care
+0.891986271986272,0.1,"300 Steam Plant Rd 430, Gallatin, TN 37066",Vanderbilt Primary Care Gallatin,"300 Steam Plant Road, Suite 430, Gallatin, TN",Vanderbilt Primary Care Gallatin
+0.8924475524475525,0.1,"33 Tower St, Somerville, MA 02143",Cambridge Health Alliance: Somerville Hospital,"33 Tower Street, Somerville MA",Somerville Hospital - Crown St. parking Test Center
+0.8929411764705882,0.0,"4455 US-36 East, Decatur, IL 62521",Respiratory Clinic at DMH ExpressCare East,"4455 E. U.S. 36, Decatur, IL 62521",Respiratory Clinic at DMH ExpressCare East
+0.8943312321260125,0.1,"27 S Cooks Bridge Rd Suite 1-5, Jackson Township, NJ 08527",Hackensack Meridian Urgent Care - Jackson,"27 S Cooksbridge Road Suite 1-5 Jackson, NJ 08527",Hackensack Meridian Urgent Care - Jackson
+0.8968487394957984,0.0,"267 Grant St, Bridgeport, CT 06610",Bridgeport Hospital,"267 Grant Street, Bridgeport, CT",Bridgeport Hospital
+0.8968487394957984,0.5,"2979 Main St, Bridgeport, CT 06606",St. Vincent’s Medical Center,"2979 Main Street, Bridgeport, CT",St. Vincent’s Medical Center
+0.8972480220158238,0.2,"35 S Sillyman St, Cressona, PA 17929",LVHN COVID-19 Assess and Test–Cressona,"35 Sillyman Street, Cressona, PA 17929",VHN COVID-19 Assess and Test–Cressona
+0.8977885891198584,0.1,"4534 Harding Pike, Nashville, TN 37205",Vanderbilt Health Walk-In Clinic Belle Meade,"4534 Harding Pike, Belle Meade, TN",Vanderbilt Health Walk-In Clinic Belle Meade
+0.899553128103277,0.1,"3098 Campbell Station Pkwy 100, Spring Hill, TN 37174",Vanderbilt Health and Williamson Medical Center Walk-In Clinic Spring Hill,"3098 Campbell Station Parkway, Suite 100, Spring Hill, TN",Vanderbilt Health & Williamson Medical Center Walk-In Clinic Spring Hill
+0.8998051948051948,4.0,"201 Chestnut Hill Rd, Stafford, CT 06076",Johnson Memorial Hospital (Stafford),"201 Chestnut Hill Road, Stafford Springs, CT",Johnson Memorial Hospital
+0.8998563141929647,0.0,"5251 W. U.S. Hwy 290 Ste 200, Austin, TX 78735",Baylor Scott & White Clinic - Austin Oak Hill,"5251 West, US-290 Ste 200, Austin, TX 78735",Baylor Scott & White Medical Center - Austin
+0.9005478022694666,0.1,"147 S Main St, Middleton, MA 01949",Middleton Family Medicine,"147 South Main Street Middleton, MA 01949",Middleton Family Medicine
+0.9007325360751952,0.3,"10251 Central Ave, Upper Marlboro, MD 20772",MDOT MVA Vehicle Inspection/Emission Center: Upper Marlboro,"10251 Central Ave, Largo, MD 20774",Motor Vehicle Administration
+0.9007928749864234,0.1,"1000 Main St, Stratford, CT 06615",Murphy Medical Associates,"1000 Main Street, Stratford, CT","Drive Thru Coronovrus Testing, Stratford Honeywell Field"
+0.900904071773637,0.0,"2950 S 6th St, Springfield, IL 62703",Respiratory Clinic at Memorial Physician Services,"2950 South Sixth Street, Springfield, IL 62703",Respiratory Clinic at Memorial Physician Services - South Sixth
+0.9027642276422764,0.3,"1630 Rio Rancho Blvd SE, Rio Rancho, NM 87124",Next Care Urgent Care - Rio Rancho,"1721 Rio Rancho Blvd. SE Rio Rancho, NM 87124",OPTUM - Rio Rancho Family Practice
+0.903968105065666,0.0,"450 S Kitsap Blvd, Port Orchard, WA 98366",Harrison Port Orchard Urgent Care,"450 S. Kitsap Blvd. Suite 100 Port Orchard, WA 98366",Harrison Port Orchard Urgent Care
+0.9049308755760368,0.1,"150 Sargent Dr, New Haven, CT 06511",Yale New Haven Hospital Diagnostic Radiology,"150 Sargent Drive, New Haven CT",Yale New Haven Health Blood Draw Station-Long Warf
+0.9051272324956535,0.0,"211 Quarry Rd 102, Palo Alto, CA 94304",Stanford Express Care Palo Alto,"211 Quarry Road Suite 102 Palo Alto, CA 94304",Stanford Health - Express Care Palo Alto
+0.9067498165810711,0.0,"900 Carillon Pkwy 106, St. Petersburg, FL 33716",BayCare Urgent Care (Carillon),"900 Carillon Parkway, Suite. 106, St. Petersburg, FL 33716",BayCare Urgent Care (Carillon)
+0.907001223990208,0.0,"5501 Herrera Drive, Santa Fe, NM 87505",Christus St. Vincent Regional Medical Center and Christus St. Vincent Hospital,"5501 Herrera Dr. Santa Fe, New Mexico 87507",Christus St. Vincent Urgent Care
+0.908265306122449,0.1,"292 Frantz Rd 102, Stroudsburg, PA 18360",LVHN COVID-19 Assess and Test–Bartonsville,"292 Frantz Road, Suite 102, Stroudsburg, PA 18360",LVHN COVID-19 Assess and Test–Bartonsville
+0.9084848484848485,0.1,"940 Oldham Dr, Nolensville, TN 37135",Vanderbilt Health and Williamson Medical Center Walk-In Clinic Nolensville,"940 Oldham Drive, Nolensville, TN",Vanderbilt Health & Williamson Medical Center Walk-In Clinic Nolensville
+0.9107342657342657,0.0,"450 Northcrest Dr, Springfield, TN 37172",NorthCrest Care Center,"450 North Crest Drive, Springfield, TN 37172",NorthCrest Care Center
+0.910952380952381,0.0,"5601 W Chinden Blvd, Garden City, ID 83714",Primary Health Medical Group,"5601 W.Chinden Blvd. Garden City, ID 83714",Primary Health - Garden City
+0.9110411140583554,0.6,"435 Lewis Ave, Meriden, CT 06451",MidState Medical Center,"435 Lewis Avenue, Meriden, CT",MidState Medical Center
+0.9121510673234811,0.0,"5 Alumni Dr, Exeter, NH 03833",Exeter Hospital,"5 Alumni Drive Exeter, New Hampshire 03833",Exeter Hospital
+0.9129124820659972,0.0,"1233 W Poplar St, Rogers, AR 72756",Rogers Community Clinic,"1233 West Poplar Street, Rogers, AR 72756",Community Clinic Rogers Medical
+0.9140316205533596,0.4,"703 Buena Vista Blvd, The Villages, FL 32162",Villages Polo Field by UF Health,"703 N Buena Vista Blvd, The Villages, FL 32162",The Villages Polo Club
+0.9147619047619048,0.1,"34 Maple St, Norwalk, CT 06850",Norwalk Hospital,"34 Maple Street, Norwalk, CT",Norwalk Hospital
+0.9147749042145594,0.1,"5 Perryridge Rd, Greenwich, CT 06830",Greenwich Hospital,"5 Perryridgy Road, Greenwich, CT",Greenwich Hospital Testing Site
+0.9148325358851676,0.1,"4280 N Valdosta Rd, Valdosta, GA 31602",SGMC Urgent Care,"4280 North Valdosta Road, Valdosta, GA 31602",South Georgia Medical Center
+0.9154761904761906,0.0,"4700 Rice Mine Rd NE, Tuscaloosa, AL 35406",Urgent Care for Children - Tuscaloosa,"4700 Rice Mine Road Northeast Tuscaloosa, AL 35406",Urgent Care for Children - Tuscaloosa
+0.9160224089635854,0.0,"1730 W Chew St, Allentown, PA 18104",LVHN COVID-19 Assess and Test–17th Street,"1730 Chew St., Allentown, PA 18104",LVHN COVID-19 Assess and Test–17th Street
+0.9160687138948009,0.0,"7305 N Military Trl, Riviera Beach, FL 33410",West Palm Beach VA Medical Center,"7305 N Military Trl, West Palm Beach, FL 33410",West Palm Beach VA Medical Center
+0.9162004662004662,0.0,"1100 N 4th St, Leavenworth, KS 66048",NextCare Urgent Care- Leavenworth,"1100 N 4th St Leavenworth, Kansas 66042",NextCare Urgent Care - Leavenworth
+0.9162280701754385,0.0,"4910 Fairfield Rd, Fairfield, PA 17320",WellSpan Family Medicine - Fairfield,"4910 Fairfield Rd. , Suite A Fairfield, PA 17320",Fairfield Family Medicine
+0.9173061173061173,0.1,"67-1125 Mamalahoa Hwy, Waimea, HI 96743",Queen’s North Hawaii Community Hospital,"67-1125 Mamalahoa Highway, Waimea, HI",Queen's North Hawaii Community Hospital
+0.9173061173061173,2.7,"540 Litchfield St, Torrington, CT 06790",Charlotte Hungerford Hospital (Torrington),"540 Litchfield Street, Torrington, CT",Charlotte Hungerford Hospital
+0.9176624442279091,0.0,"280 Home Olu Pl, Kaunakakai, HI 96748",Molokai General Hospital,"280 Home Olu Place, Kaunakakai, HI",Molokai General Hospital
+0.9177766032417195,0.0,"1400 Jackson St, Denver, CO 80206",National Jewish Health,"1400 Jackson Street, Denver, Colorado 80206",National Jewish Health Main Campus
+0.9186679174484051,0.0,"7131 Frankford Ave 2nd Floor, Philadelphia, PA 19135",Einstein Physicians Mayfair,"7131 Frankford Ave Philadelphia, PA 19135",Einstein Healthcare Network testing Site
+0.919675417043838,0.0,"330 N Eisenhower Dr, Beckley, WV 25801",Amjad Medical Clinic,"330 North Eisenhower Drive Beckley, WV 25801",Dr. Ayne Amjad M.D.
+0.919751218183469,0.0,"2350 Schillinger Rd S Suite A, Mobile, AL 36695",Greater Mobile Urgent Care,"2350 Schillinger Rd., Mobile, AL 36695",Greater Mobile Urgent Care
+0.9200956937799044,0.0,"3025 W Cherry Ln B, Meridian, ID 83642",Saint Alphonsus,"3025 West Cherry Lane #B, Meridian, ID 83642",Saint Alphonsus Meridian Health Plaza
+0.9207459207459208,0.1,"1475 W 49th Pl, Hialeah, FL 33012",Larkin Community Hospital,"1475 West 49th Place, Hialeah, FL 33012",Larkin Community Hospital - Palm Springs Campus
+0.9208372093023256,0.0,"254 Ren Mar Dr 100, Pleasant View, TN 37146",Regents Medical Center,"254 Ren Mar Dr, Suite 100, Pleasant View, TN 37146",Regents Medical Center
+0.9218487394957984,0.0,"1691 Galisteo St Ste D, Santa Fe, NM 87505",Southwest CARE Center,"1691 Galisteo St, Ste D, Santa Fe, New Mexico 87505",Southwest CARE - Southwest CARE Center - Pediatrics
+0.9221611721611722,0.0,"1998 Market St, SF, CA 94102",Carbon Health,"1998 Market St, San Francisco, CA 94102",Carbon Health - SF Castro
+0.9247902265118908,0.0,"6030 S 66th E Ave, Tulsa, OK 74145",Access Family Medical,"6030 S 66th East Avenue, Tulsa, Ok, 74145",Access Family Medical
+0.9259999999999999,0.0,"800 Weatherly Dr 201B, Clarksville, TN 37043",Vanderbilt Primary Care Clarksville,"800 Weatherly Dr Suite 201B, Clarksville, TN 37043",Vanderbilt Primary Care Clarksville
+0.9262539568057058,0.0,"3181 SW Sam Jackson Park Rd, Portland, OR 97239",Oregon Health & Science University (OHSU) Hospital,"3181 S.W. Sam Jackson Park Road Portland, Oregon 97239-3098",Oregon Health & Sciences University Hospital (OHSU)
+0.9268855368234251,0.0,"1150 W El Camino Real, Mountain View, CA 94040",El Camino Health Urgent Care,"1150 West El Camino Real, Mountain View, CA 94040",El Camino Health Urgent Care - Mountain View
+0.9270609318996416,0.1,"4247 W Ridge Rd, Erie, PA 16506",AHN West Side Health + Wellness Pavilion,"4247 West Ridge Road, Erie, PA 16506",AHN West Side Health + Wellness Pavilion
+0.927433155080214,5.3,"264 W 118th St, New York, NY 10026","NYC Health + Hospitals/Gotham Health, Sydenham","216 E 14th St, New York, NY 10003",East 14th Urgent Care
+0.9274991674991675,0.0,"600 S Dobson Rd, Chandler, AZ 85224",Next Care Urgent Care - Chandler,"600 S Dobson Rd Chandler, Arizona 85224",NextCare Urgent Care
+0.9280172413793103,0.0,"320 W Pumping Station Rd 3, Quakertown, PA 18951",LVHN COVID-19 Assess and Test­­–Richland Township,"320 W. Pumping Station Road, Suite 3, Quakertown, PA 18951",LVHN COVID-19 Assess and Test - Richland Township
+0.9286763686763687,0.2,"2245 Callaway Rd SW, Marietta, GA 30008",Jim Miller Park,"2245 Callaway Road Marietta, GA 30008",Jim R. Miller Park
+0.9291150709755361,0.0,"2075 University Park Blvd, Layton, UT 84041",Layton Clinic,"2075 N University Park Blvd Layton, UT 84041",Layton Clinic
+0.9293290043290043,0.0,"1860 N Church Rd, Liberty, MO 64068",Next Care Urgent Care,"1860 N Church Rd Liberty, Missouri 64068",Next Care Urgent Care
+0.9293290043290043,0.0,"1701 E Thomas Rd, Phoenix, AZ 85016",Next Care Urgent Care - Phoenix (E Thomas Rd),"1701 E Thomas Rd. Phoenix, Arizona 85016",NextCare Urgent Care
+0.9294276094276094,0.1,"2131 Industrial Pkwy, Silver Spring, MD 20904",MDOT MVA Vehicle Inspection/Emission Center: White Oak,"2121 Industrial Parkway, Silver Spring, MD 20904",VEIP converted to COVID TESTING SITE - Silver Spring
+0.9294771241830065,0.0,"18589 N 59th Ave, Glendale, AZ 85308",Next Care Urgent Care - Glendale (N. 59th Ave),"18589 N 59th Ave Glendale, Arizona 85308",NextCare Urgent Care
+0.9298654244306418,0.0,"2025 Glenn Mitchell Dr, Virginia Beach, VA 23456",Sentara Princess Anne Hospital,"2025 Glenn Mitchell Drive Virginia Beach, Virginia 23456",Sentara Princess Anne Hospital
+0.9304263777947989,0.1,"181 Medical Tower Dr, Murray, UT 84107",Cottonwood InstaCare,"181 E Medical Tower Dr Murray, UT 84107",Cottonwood Instacare
+0.9315208825847123,0.0,"1679 E Monte Vista Ave 104, Vacaville, CA 95688",NorthBay HealthCare - Vacaville,"1679 E Monte Vista Ave, Suite 104, Vacaville, CA 95688",NorthBay HealthCare - Vacaville
+0.9317307692307691,0.1,"201 King of Prussia Rd, Wayne, PA 19087",Penn Medicine Radnor,"250 King of Prussia Rd, Radnor, PA 19087",Radnor Coronavirus Testing Site - Penn Medicine
+0.9319815668202764,0.2,"200 N 400 E St, Panguitch, UT 84759",Garfield Memorial Hospital,"200 N 400 E Panguitch, UT 84759",Garfield Memorial Hospital
+0.9326640926640927,0.2,"2424 W Jefferson St, Joliet, IL 60435",Walmart (Parking Lot),"2424 West Jefferson, Joliet, IL 60435",Walmart - parking lot
+0.9333553065260383,0.5,"125 Michigan Ave NE, Washington, DC 20017",Children's National Hospital,"111 Michigan Ave NW, Washington, DC 20010",Children's National Hospital
+0.9346195949644225,0.0,"9450 1300 E, Sandy, UT 84094",Alta View InstaCare,"9450 S 1300 E Sandy, UT 84094",Alta View InstaCare
+0.9356623669123669,0.0,"315 W Main St, Freehold, NJ 07728",Hackensack Meridian Urgent Care - Freehold,"315 W. Main Street Freehold, NJ 07728",Hackensack Meridian Urgent Care - Freehold
+0.9363924963924964,0.3,"215 Applegarth Rd, Monroe Township, NJ 08831",Hackensack Meridian Urgent Care - Monroe,"215 Applegarth Road Monroe, NJ 08831",Hackensack Meridian Urgent Care - Monroe
+0.9369953543152523,0.0,"1000 State St, McCall, ID 83638",St. Luke's McCall Medical Center-Parking Lot,"1000 State St. McCall, Idaho 83638",St. Luke's McCall Medical Center
+0.9370637536491194,0.0,"5920 W McDowell Rd, Phoenix, AZ 85035",Next Care Urgent Care - Phoenix (W McDowell Rd),"5920 W McDowell Rd Phoenix, Arizona 85035",NextCare Urgent Care
+0.937140763849499,0.0,"9494 W Northern Ave 101, Glendale, AZ 85305",Next Care Urgent Care - Glendale (W. Northern Ave.),"9494 W Northern Ave #101 Glendale, Arizona 85305",NextCare Urgent Care
+0.9373868091454741,0.1,"3723 W 12600 S 150, Riverton, UT 84065",Southridge InstaCare,"3723 W 12600 S Ste 150 Riverton, UT 84065",Southridge InstaCare
+0.9376847745750185,0.0,"98-199 Kamehameha Hwy Bldg F, Aiea, HI 96701",Queen’s Island Urgent Care-Pearl Kai,"98-199 Kamehameha hwy building f, Aiea, HI 96701",Queens Island Urgent Care- Pearl Kai
+0.9388384754990925,0.2,"105 Pearl St, Essex, VT 05452",Champlain Valley Expo,"105 Pearl St, Essex Junction, VT 05452",Champlain Valley Expo
+0.9392329239388063,0.1,"115 Porter Dr, Middlebury, VT 05753",Porter Hospital,"115 Porter Drive  Middlebury, VT  05753",Porter Hospital
+0.9392329239388063,0.1,"30 Locust St, Northampton, MA 01060",Cooley Dickinson Hospital,"30 Locust Street, Northampton, MA 01061",Cooley Dickinson Hospital
+0.9393892339544514,0.0,"2122 N Scottsdale Rd, Scottsdale, AZ 85257",Next Care Urgent Care - Oak (Scottsdale),"2122 N Scottsdale Rd Scottsdale, Arizona 85257",NextCare Urgent Care
+0.9396203796203796,0.1,"919 Murfreesboro Rd, Franklin, TN 37064",Vanderbilt Health and Williamson Medical Center Walk-In Clinic Franklin,"919 Murfreesboro Road, Franklin, TN",Vanderbilt Health & Williamson Medical Center Walk-In Clinic Franklin
+0.9397515527950311,0.0,"19600 Vallco Pkwy 170, Cupertino, CA 95014",El Camino Health Urgent Care,"19600 Vallco Pkwy Ste 170, Cupertino, CA 95014",El Camino Health Urgent Care - Cupertino
+0.9418103448275862,0.4,"1830 Katyland Dr, Katy, TX 77493",Katy ISD - Legacy Stadium,"1830 Katyland Drive, Katy, TX",Katy ISD – Legacy Stadium Testing Site
+0.9420190779014309,0.3,"1120 W State Fair Ave, Detroit, MI 48203",Michigan State Fairgrounds,"1120 W State Fair Avenue, Detroit, MI",Coronavirus Community Care Network Drive Thru Testing
+0.9432609079667903,0.0,"2805 Overseas Hwy, Marathon, FL 33050",Marathon Health Center,"2805 Overseas HWY Marathon, FL 33050",Community Health of South Florida - Marathon
+0.943939393939394,0.0,"1919 College Dr, Gallup, NM 87301",NMDOH NW Region - Gallup Public Health Office,"1919 College Drive, Gallup, New Mexico 87301",Gallup Public Health Office - McKinley County
+0.9441145281018027,0.1,"701 E Marshall St, West Chester, PA 19380",Chester County Hospital,"701 E. Marshall Street, West Chester, PA 19380",Chester County Hospital
+0.9446241995281429,0.0,"5133 Rivers Ave, North Charleston, SC 29406",Roper St. Francis Physician Partners Primary Care,"5133 Rivers Avenue North Charleston, SC  29406",Roper St. Francis Physician Partners Primary Care
+0.9447104247104247,0.2,"700 Halia Nakoa St, Wailuku, HI 96793",War Memorial Gym parking lot,"700 Halia Nakoa Street, Wailuku, HI",War Memorial Gymnasium Parking Lot
+0.9452017648680945,0.1,"2570 Riverside Pkwy, Lawrenceville, GA 30046",Lawrenceville,"2570 Riverside Parkway Lawrenceville, GA 30046",Lawrenceville Drive Thru Site
+0.9453510436432637,0.0,"700 Caldwell Blvd, Nampa, ID 83651",Primary Health Medical Group,"700 Caldwell Blvd. Nampa, ID 83686",Primary Health Clinic
+0.9456535644030364,0.0,"132 5th Ave W Suite 1 & 2, Jerome, ID 83338",St. Luke's Jerome Family Medicine,"132 5th Ave. W. Suites 1 and 2 Jerome, ID 83338",St. Luke's Jerome Family Medicine
+0.9464285714285714,0.0,"625 W 12th St, Wilmington, DE 19801",ChristianaCare - Wilmington Campus,"625 W. 12th Street, Wilmington, DE 19801",Roxana Cannon Arsht Surgicenter
+0.9470449172576832,0.0,"146 Passion Play Rd, Eureka Springs, AR 72632",Eureka Springs Family Medical Clinic,"146 Passion Play Rd b, Eureka Springs, AR 72632",Washington Regional Eureka Springs Family Clinic (8-4:30)
+0.9471198471198472,0.0,"3122 E Meridian Park Loop, Wasilla, AK 99654",Capstone Clinic,"3122 E Meridian Park Lp.  Wasilla, AK",Capstone Clinic
+0.9476623376623377,0.0,"3280 E Lanark St, Meridian, ID 83642",Primary Health Medical Group,"3280 E Lanark Dr Meridian, ID 83642",Primary Health - Meridian Crossroads
+0.9482536011947776,0.0,"12311 Perry Hwy, Wexford, PA 15090",AHN Wexford Health + Wellness Pavilion,"12311 Perry Highway Wexford, PA 15090",Wexford Health + Wellness Pavilion (Allegheny Health Network)
+0.9486587011619104,0.0,"10 Montgomery Dr, Arkadelphia, AR 71923",Baptist Health Family Clinic-Caddo Valley,"10 Montgomery Drive, Arkadelphia AR 71923",Baptist Health Family Clinic-Caddo Valley
+0.9499511241446726,0.0,"1601 Trinity St, Austin, TX 78701",UT Health Austin,"1601 Trinity St. Austin, Tx 78701",UT Health Austin (Dell Medical Clinical Practice)
+0.9500189753320682,0.0,"1030 Main St, Waltham, MA 02451",AFC Urgent Care,"1030 Main Street, Waltham MA 02451",AFC Urgent Care - Waltham
+0.9501501501501503,0.0,"389 S 900 E, Salt Lake City, UT 84102",Salt Lake InstaCare,"389 S 900 E Salt Lake City, UT 84102",Salt Lake InstaCare
+0.951207729468599,0.1,"1320 Travis Blvd Suite C, Fairfield, CA 94533",Carbon Health,"1320 Travis Blvd, Suite C, Fairfield, CA 94533",NorthBay HealthCare - Fairfield
+0.9522222222222222,239.2,"140 N Sherman Ct, Hazleton, PA 18201",LVHN COVID-19 Assess and Test–Sherman Court,"140 N. Sherman Court, Hazleton, PA 18201",Shrewsbury CVS
+0.9523861236802413,0.0,"1344 Wintergreen Ln NE, Bainbridge Island, WA 98110",Franciscan Medical Clinic,"1344 Wintergreen Lane NE Bainbridge Island, WA 98110",Franciscan Medical Clinic
+0.9525675675675677,1.5,"365 Montauk Ave, New London, CT 06320",Lawrence and Memorial Hospital (New London),"365 Montauk Avenue, New London, CT 06320",Lawrence + Memorial Hosptial
+0.9535353535353536,0.2,"3250 Meridian Pkwy, Weston, FL 33331",Krupa Center,"3250 Meridian Parkway, Weston, Florida 33331",Cleveland Clinic Florida (Krupa Center)
+0.9548333333333333,0.0,"5150 Journal Center Blvd NE, Albuquerque, NM 87109",Journal Center Urgent Care,"5150 Journal Center Blvd. SE Albuquerque, NM 87109",OPTUM
+0.956060606060606,0.0,"4220 William Penn Hwy, Monroeville, PA 15146",AHN Drive Thru Site,"4220 William Penn Highway, Monroeville, PA 15146",Allegheny Health Network
+0.9563888888888888,0.1,"600 Highland Oaks Dr, Winston-Salem, NC 27103",Novant Health Urgent Care,"600 Highland Oaks Drive, Winston-Salem, NC 27103",Novant Health Screening Center
+0.9563888888888888,0.0,"2121 Industrial Pkwy, Silver Spring, MD 20904",MDOT MVA Vehicle Inspection/Emission Center: Silver Spring,"2121 Industrial Parkway, Silver Spring, MD 20904",VEIP converted to COVID TESTING SITE - Silver Spring
+0.9564393939393939,0.0,"962 Sage Dr, Cedar City, UT 84720",Cedar City InstaCare,"962 Sage Dr Cedar City, UT 84720",Cedar City Instacare
+0.9567251461988304,0.4,"3109 Wrightsboro Rd, Augusta, GA 30909",Augusta University’s Christenberry Fieldhouse,3109 Wrightsboro Road Augusta GA 30909,Augusta University Health (Christenberry Fieldhouse)
+0.956987756987757,0.0,"1010 Higbee Dr, Bethel Park, PA 15102",AHN Bethel Park Health + Wellness Pavilion,"1010 Higbee Drive Bethel Park, PA 15102",Bethel Park Health + Wellness Pavilion (Allegheny Health Network)
+0.9577540106951872,0.1,"5450 GA-20, Cartersville, GA 30121",Clarence Brown Conference Center,"5450 GA-20 Cartersville, GA 30121",Clarence Brown Conference Center
+0.9577540106951872,0.1,"762 W 400 S, Springville, UT 84663",Springville InstaCare,"762 W 400 S Springville, UT 84663",Springville InstaCare
+0.9579322638146167,0.0,"104 Legion Dr, Las Vegas, NM 87701",Alta Vista Regional Hospital,"104 Legion Dr. Las Vegas, NM 87701",Alta Vista Regional Hospital
+0.9580808080808082,0.1,"615 Prospect Ave, Springer, NM 87747",Colfax General Lab,"615 Prospect Ave, Springer, New Mexico 87747",South Central Colfax County - Colfax General Lab
+0.9591025641025642,0.0,"556 Passaic Ave, West Caldwell, NJ 07006",The Doctors' Office Urgent Care West Caldwell,"556 Passaic Ave West Caldwell, NJ 07006",The Doctor’s Office Urgent Care of West Caldwell
+0.9592171717171717,0.0,"933 W Race St, Kingston, TN 37763",Summit Medical Group,"933 W Race Street Kingston, TN 37763",Summit Medical Group (drive thru)
+0.9599613152804642,0.1,"1 TIAA Bank Field Dr, Jacksonville, FL 32202",Lot J (At TIAA Bank Field),"1 TIAA Bank Field Drive, Jacksonville, FL 32202",TIAA Bank Field
+0.96,0.1,"5917 Belt Line Rd, Dallas, TX 75254",Neighborhood Medical Center,"5917 Belt Line Rd, Dallas TX",Neighborhood Medical Center Clinic
+0.9601219512195123,0.3,"300 Wendover Ave E, Greensboro, NC 27401",Cone Health,"300 E. Wendover Ave, Greensboro, NC 27401",Cone Health Drive-Thru Collection Center
+0.9601587301587302,0.0,"577 S River Rd, St. George, UT 84790",River Road InstaCare,"577 S River Rd St. George, UT 84790",River Road InstaCare
+0.9604761904761904,0.0,"3250 Alpine Rd, Portola Valley, CA 94028",Stanford Primary Care in Portola Valley,"3250 Alpine Road, Portola Valley, CA 94028",Stanford Primary Care in Portola Valley
+0.9606177606177606,0.0,"6451 Village Ln, Macungie, PA 18062",LVHN COVID-19 Assess and Test–Macungie,"6451 Village Lane, Macungie, PA 18062",LVHN COVID-19 Assess and Test - Macungie
+0.9610483870967742,0.4,"300 Pompton Rd, Wayne, NJ 07470",William Paterson University,"300 Pompton Road Wayne, NJ 07470",William Paterson University
+0.9612612612612612,0.0,"3845 W 4700 S, Taylorsville, UT 84129",Taylorsville InstaCare,"3845 W 4700 S Taylorsville, UT 84129",Taylorsville InstaCare
+0.9620364550597109,0.0,"200 SE Hospital Ave, Stuart, FL 34994",Cleveland Clinic - Martin Health,"200 SE Hospital Ave., Stuart, Florida 34994",Martin North Hospital
+0.9623044096728307,0.0,"433 Fairview Ave, Ponca City, OK 74601",Kay County Health Department,"433 Fairview Ave Ponca City, OK 74601",Oklahoma Health Department Drive Thru Testing-Kay County
+0.9625,0.2,"775 Norman Dr, Lebanon, PA 17042",WellSpan Cardiovascular Diagnostic Center,"720 Norman Dr, Lebanon, PA 17042",WellSpan Family Medicine - Norman Drive
+0.9625,0.1,"130 Division St, Derby, CT 06418",Griffin Hospital,"130 Division St, Derby, CT",Griffin Health COVID-19 Drive-Up Test Collection Site
+0.9628787878787879,0.0,"555 N Broadway, Jericho, NY 11753",ProHEALTH Urgent Care - Jericho - EXPANDED HOURS,"555 N. Broadway Jericho, NY 11753",ProHEALTH Urgent Care of Jericho
+0.9629629629629629,0.5,"400 W Maple St, Farmington, NM 87401",San Juan Regional Medical Center,"801 W Maple St, Farmington, NM 87401",San Juan Regional Medical Center
+0.9630021141649049,0.0,"13701 Encantado Rd NE, Albuquerque, NM 87123",Tramway Center,"13701 Encantado Rd. NE Albuquerque, NM 87123",OPTUM
+0.9633783783783784,0.0,"15214 Canyon Rd E, Puyallup, WA 98375",Franciscan Medical Pavilion,"15214 Canyon Road E., Puyallup, WA 98375",Franciscan Prompt Care - Canyon Road
+0.9638146167557933,0.1,"6 Glen Cove Dr, Rockport, ME 04856",Pen Bay Medical Center,"6 Glen Cove Dr Rockport, ME 04856",Pen Bay Medical Center
+0.9638146167557933,0.0,"1010 Spruce St, Española, NM 87532",Presbyterian Espanola Hospital,"1010 Spruce St Española, NM 87532",Presbyterian Española Hospital
+0.9638383838383838,0.0,"1721 Rio Rancho Blvd SE, Rio Rancho, NM 87124",Rio Rancho Center,"1721 Rio Rancho Blvd. SE Rio Rancho, NM 87124",OPTUM - Rio Rancho Family Practice
+0.9641025641025641,0.2,"5201 Harry Hines Blvd, Dallas, TX 75390",Parkland Health and Hospital System,"5200 Harry Hines Blvd, Dallas, TX 75235",Parkland Memorial Hospital
+0.9652014652014652,0.0,"7401 Ogontz Ave, Philadelphia, PA 19138",Rite Aid,"7401 Ogontz Avenue, Philadelphia, PA 19138",Rite Aid Redi Clinic
+0.9652777777777778,0.2,"111 Gateway Center Dr, Kernersville, NC 27284",Novant Health Urgent Care,"111 Gateway Center Drive, Kernersville, NC 27284",Novant Health Screening Center
+0.9654761904761905,0.1,"1000 N Main St Ste. A, Richfield, UT 84701",Sevier Valley Clinic,"1000 N Main St Ste A Richfield, UT 84701",Sevier Valley Clinic
+0.9658730158730159,0.1,"600 Gillmor Way, Park City, UT 84060",Park City Ice Rink,"600 Gillmor Way Park City, UT 84060",Park City Ice Rink
+0.9667774086378738,0.0,"9621 Ridgetop Blvd NW, Silverdale, WA 98383",The Doctors Clinic Ridgetop East,"9621 Ridgetop Blvd NW Silverdale, WA 98383",The Doctors Clinic Ridgetop East
+0.967016317016317,0.0,"2116 Jackson Blvd, Rapid City, SD 57702",Monument Health Urgent Care West,"2116 Jackson Boulevard, Rapid City, SD 57702",Monument Health Rapid City Urgent Care
+0.9671826625386997,0.2,"602 Indiana Ave, Lubbock, TX 79415",UMC Health System,"602 Indiana Avenue, Lubbock, TX, 79415",UMC COVID 19 Testing Site
+0.9679435483870968,0.0,"300 Wilson St, Clayton, NM 88415",Union County General Hospital,"300 Wilson St Clayton, NM 88415",Union County General Hospital
+0.9679435483870968,0.0,"525 N Main St, Ephraim, UT 84627",Ephraim Clinic,"525 N Main St Ephraim, UT 84627",Ephraim Clinic
+0.9682828282828283,0.0,"2975 Maynardville Hwy, Maynardville, TN 37807",Maynardville Express Care,"2975 Maynardville Hwy Maynardville, TN 37807",Maynardville Express Care
+0.9682828282828283,0.0,"2400 N Washington Blvd, North Ogden, UT 84414",North Ogden InstaCare,"2400 N Washington Blvd North Ogden, UT 84414",North Ogden InstaCare
+0.9685560053981107,0.1,"55 Meadowlands Pkwy, Secaucus, NJ 07094",Hudson Regional Hospital,"55 Meadowlands Pkwy Secaucus, NJ 07094",Hudson Regional Hospital
+0.9686909581646423,0.0,"6812 Harrisburg Blvd, Houston, TX 77011",MD Kids Pediatrics - Harrisburg Location,"6812 Harrisburg Blvd. Houston, TX 77011",MD Kids Pediatrics - Harrisburg Location
+0.9689393939393939,0.1,"1501 Hiland Ave, Burley, ID 83318",Cassia Regional Hospital,"1501 Hiland Ave Burley, ID 83318",Cassia Regional Hospital
+0.9693589743589744,0.0,"169 Westmoreland St, Harrogate, TN 37752",Harrogate Family Health Care,"169 Westmoreland St Harrogate, TN 37752",Harrogate Family Health Care
+0.969449715370019,0.0,"200 Hygeia Dr, Newark, DE 19713",ChristianaCare - GoHealth Urgent Care,"200 Hygeia Drive, Newark, DE 19713",HealthCare Center of Christiana
+0.969676994067238,0.2,"300 Enterprise Dr, Kingston, NY 12401",Tech CIty,"300 Enterprise Drive, Kingston, NY, 12401",Nuvance Health
+0.9700000000000001,0.2,"263 Farmington Ave, Farmington, CT 06032",UConn John Dempsey Hospital,"263 Farmington Ave, Farmington, CT",UConn Health Drive-Through COVID-19 Sampling Site
+0.9700534759358289,0.1,"914 Shorter Ave NW, Rome, GA 30165",West Rome Baptist Church,"914 Shorter Ave NW; Rome, GA 30165",West Rome Baptist Church
+0.9702439024390244,0.1,"400 W Mineral King Ave, Visalia, CA 93291",Kaweah Delta Heatlh Care District,"400 W Mineral King Ave. Visalia, CA 93291",Kaweah Delta Medical Center
+0.97056786350904,0.0,"67 Valley Rd, Middletown, RI 02842",Ocean State Urgent Care of Middletown,"67 Valley Rd.  Middletown, RI 02842",Ocean State Urgent Care - Middletown
+0.9708478513356562,0.1,"4771 S Cleveland Ave, Fort Myers, FL 33907",Page Field Convenient Care,"4771 S Cleveland Av, Fort Myers, FL 33907",Lee Convenient Care
+0.9712418300653595,0.1,"3249 N 1200 W Ste. A, Lehi, UT 84043",Lehi Clinic InstaCare,"3249 N 1200 W Ste A Lehi, UT 84043",Lehi Clinic Instacare
+0.9714098972922501,0.0,"1131 Warwick Ave, Warwick, RI 02888",Ocean State Urgent Care of Warwick,"1131 Warwick Ave.  Warwick, RI 02888",Ocean State Urgent Care - Warwick
+0.9715873015873016,0.0,"118 Northport Ave, Belfast, ME 04915",Waldo County General Hospital,"118 Northport Ave Belfast, ME 04915",Waldo County General Hospital
+0.9719047619047619,0.0,"510 W Tidwell Rd, Houston, TX 77076",United Memorial Medical Center,"510 W Tidwell Rd, Houston, TX, 77091",United Memorial Medical Center - Tidwell
+0.9720190779014308,0.0,"100 Hospital Dr, Ketchum, ID 83340",St. Luke's Wood River Hospital,"100 Hospital Drive, Ketchum, ID 83340",St. Luke's Wood River Medical Center
+0.9721227621483376,0.0,"2330 S Congress Ave, West Palm Beach, FL 33406",FoundCare,"2330 S Congress Ave, West Palm Beach, Florida 33406",Foundcare Inc
+0.9723723723723724,0.0,"100 E Michigan Ave, Jackson, MI 49201",Henry Ford Allegiance Health,"100 E Michigan Ave Jackson, MI 49201",Henry Ford Allegiance Health One Jackson Square
+0.9726436781609196,0.0,"1397 Weimer Rd, Taos, NM 87571",Holy Cross Hospital,"1397 Weimer Rd Taos, NM 87571",Holy Cross Medical Center
+0.9732330827067669,0.0,"31 Physicians Dr, Jackson, TN 38305",West TN Healthcare - UT Medicine North,"31 Physicians Drive, Jackson, TN 38351",West TN Healthcare - UT Medicine North
+0.9733997155049786,0.1,"6430 Hillcroft Ave, Houston, TX 77074",My Family Doctor Houston COVID19DRIVETHRU,"6430 Hillcroft Ave, Houston, TX, 77081",My Family Doctor Drive Thru
+0.9735042735042735,0.0,"1440 E Butler Pike, Ambler, PA 19002",Temple University Ambler Campus,"1440 East Butler Pike, Ambler, PA 19002",Temple University Ambler - Upper Dublin Township
+0.9735483870967742,0.0,"777 N Main St, Tooele, UT 84074",Tooele InstaCare,"777 N Main St Tooele, UT 84074",Tooele InstaCare
+0.9738191632928476,0.0,"5366 Mendenhall Mall, Memphis, TN 38115",Christ Community Health Services Hickory Hill Health Center,"5366 Mendenhall Mall Memphis, TN 38115",Christ Community Health Services Hickory Hill Health Center
+0.9741891891891892,0.0,"1325 Jefferson Ave, Memphis, TN 38104",Baptist Operation Outreach Homeless Health Center,"1325 Jefferson Avenue, Memphis, TN 38104",Baptist Operation Outreach Homeless Health Center
+0.9747619047619047,0.4,"10 Sunnybrook Rd, Raleigh, NC 27610",Wake County Public Health Center,"111 Sunnybrook Rd, Raleigh, NC 27610",UNC Hospitals at WakeBrook
+0.9754990925589837,0.0,"601 Dr Martin Luther King Jr Ave NE, Albuquerque, NM 87102",Lovelace Medical Center,"601 Dr Martin Luther King Jr Ave NE Albuquerque, NM 87102",Lovelace Medical Center
+0.9757575757575758,0.0,"16045 1st Ave S, Burien, WA 98166",Franciscan Prompt Care,"16045 1st Ave S, Burien, WA 98148",Franciscan Prompt Care – Burien
+0.9759969028261711,0.8,"289 McClellandtown Rd, Uniontown, PA 15401",Uniontown MedExpress Urgent Care Center,"86 McClellandtown Rd, Uniontown, PA 15401",Uniontown Family Doctors
+0.9761029411764706,0.0,"10300 SW 216th St, Miami, FL 33190","Community Health of South Florida, Inc.","10300 SW 216 ST, Miami, FL 33190",Community Health of South Florida Doris Ison Health Center
+0.9778658536585366,0.7,"9800 International Dr, Orlando, FL 32819",Orange County Convention Center,"9400 International Dr, Orlando, FL, 32819",Orange County Convention Center - North Concourse Parking Lot
+0.9780780780780781,0.1,"400 Putnam Pike, Smithfield, RI 02917",Ocean State Urgent Care of Smithfield,"400 Putnam Pike  Smithfield, RI 02917",Ocean State Urgent Care - Smithfield
+0.9783533765032377,0.0,"7213 Old Alexandria Ferry Rd, Clinton, MD 20735",MDOT MVA Vehicle Inspection/Emission Center: Clinton,"7213 Old Alexandria Ferry Rd Clinton, MD 20735",Motor Vehicle Administration
+0.9799874921826142,0.1,"4201 Winfield Rd, Warrenville, IL 60555",Edward-Elmhurst Health Corporate Center (Parking Lot),"4201 Winfield Road, Warrenville, IL 60555",Edward-Elmhurst Health - Parking Lot
+0.9804878048780488,0.1,"757 Westwood Plaza, Los Angeles, CA 90024",UCLA Health,"757 Westwood Plaza, Los Angeles, CA 90095",Ronald Reagan UCLA Medical Center
+0.9809415768576291,0.0,"209 Irish Cemetery Rd, Tazewell, TN 37879",Family Medical Clinic - Tazewell,"209 Irish Cemetery Road, Tazewell, TN 37879",Family Medical Clinic – Tazewell
+0.9842105263157895,0.0,"1500 Lansdowne Ave, Darby, PA 19023",Mercy Catholic Medical Center - Mercy Fitzgerald Campus,"1500 Lansdowne Avenue, Darby, PA 19023",Mercy Fitzgerald Hospital
+0.985,0.0,"2400 N Ashland Ave, Chicago, IL 60614",Innovative Express Care,"2400 N Ashland Avenue, Chicago, IL 60614",Innovative Express Care
+0.9860465116279069,0.1,"575 Pole Line Rd W, Twin Falls, ID 83301",St. Luke's Surgery Center at the Magic Valley,"575 Pole Line Rd. W., Twin Falls, ID, 83301",St. Luke's Magic Valley
+0.9882352941176471,0.0,"123 Summer St, Worcester, MA 01604",Saint Vincent Hospital,"123 Summer St, Worcester, MA 01608",St Vincent Hospital at Worcester Medical Center
+0.9882352941176471,0.1,"800 E Park Blvd, Boise, ID 83712",St. Luke's Plaza,"800 E. Park Blvd., Boise, ID 83712",St. Luke's Plaza
+0.9888888888888889,0.0,"3201 W Saner Ave, Dallas, TX 75233",MD Kids Pediatrics - Saner Location,"3201 W. Saner Ave., Dallas, TX 75233",MD Kids Pediatrics - Saner Location
+0.9888888888888889,0.1,"701 Grove Rd, Greenville, SC 29605",Prisma Health Greenville Memorial Medical Campus,"701 Grove Road, Greenville, SC 29605",Greenville Memorial Medical Campus
+0.9891891891891892,0.0,"9991 Marsh Ln 100, Dallas, TX 75220",MD Family Clinic - Marsh Location,"9991 Marsh Ln. #100, Dallas, TX 75220",MD Family Clinic - Marsh Location
+0.9894736842105263,0.0,"7800 Preston Rd 300, Plano, TX 75024",MD Kids Pediatrics - West Plano Location,"7800 Preston Rd. #300, Plano, TX 75024",MD Kids Pediatrics - West Plano Location
+0.9897435897435898,0.0,"1655 W Main St, Stroudsburg, PA 18360",LVHN COVID-19 Assess and Test–Stroudsburg­,"1655 W. Main St., Stroudsburg, PA 18360",LVHN COVID-19 Assess and Test - Stroudsburg
+0.9904761904761905,0.2,"4200 South Fwy 106, Fort Worth, TX 76115",Clinicas Mi Doctor - Seminary Location,"4200 South Fwy. #106, Fort Worth, TX 76115",Clinicas Mi Doctor
+0.992,0.2,"325 N State of Franklin Rd, Johnson City, TN 37604",ETSU Health,"325 N State of Franklin Rd, Johnson City, TN 37614",ETSU Health (drive through) at 325 N State of Franklin Rd
+0.9930232558139535,1.4,"100 Michigan St NE, Grand Rapids, MI 49503",Spectrum Health Butterworth Hospital,"1300 Michigan St NE, Grand Rapids, MI 49503",Spectrum Health
+0.993939393939394,0.0,"9709 Bruton Rd, Dallas, TX 75217",MD Family Clinic - Bruton Location,"9709 Bruton Rd., Dallas, TX 75217",MD Family Clinic - Bruton Location
+0.993939393939394,0.0,"7545 Main St, Woodstock, GA 30188",Cherokee County Health Department,"7545 Main St, Woodstock GA 30188",Cherokee County Government Complex
+0.9941176470588236,0.0,"450 N 11th St, Beaumont, TX 77702",Legacy Community Health Central Beaumont,"450 N 11th St, Beaumont, TX, 77702",Legacy Central Beaumont
+0.9941176470588236,0.0,"3811 Lyons Ave, Houston, TX 77020",Legacy Community Health Fifth Ward,"3811 Lyons Ave., Houston, TX 77020","Legacy Community Health, Fifth Ward"
+0.9941666666666666,0.0,"46-021 Kamehameha Hwy, Kaneohe, HI 96744",Windward Urgent Care - Walgreens,"46-21 Kamehameha Hwy, Kaneohe, HI 96744",Walgreens
+0.9942857142857143,0.1,"520 S Eagle Rd, Meridian, ID 83642",St. Luke's Meridian Medical Center,"520 S. Eagle Rd, Meridian, ID 83642",St. Luke's Meridian Hospital
+0.9944444444444445,0.0,"1125 Shadow Ln, Las Vegas, NV 89102",University of Nevada Las Vegas,"1125 Shadow Ln, Las Vegas, NV, 89102",UNLV Medicine
+0.9945945945945945,0.0,"400 Keawe St 100, Honolulu, HI 96813",Queen’s Island Urgent Care-Kakaako,"400 Keawe St #100, Honolulu, HI 96813",Queen's Island Urgent Care - Kakaako
+0.9945945945945945,0.0,"6441 High Star Dr, Houston, TX 77074",Legacy Community Health Southwest,"6441 High Star Dr, Houston, TX, 77074",Legacy Southwest
+0.9947368421052633,0.0,"528 Delaware Ave, Palmerton, PA 18071",LVHN COVID-19 Assess and Test–Palmerton,"528 Delaware Ave., Palmerton, PA 18071",LVHN COVID-19 Assess and Test - Palmerton
+0.9947368421052633,0.0,"1415 California St, Houston, TX 77006",Legacy Community Health,"1415 California St., Houston, TX 77006",Legacy Montrose
+0.9947368421052633,0.0,"1 Medical Park Blvd, Bristol, TN 37620",Bristol Regional Medical Center,"1 Medical Park Blvd, Bristol, TN 37260",Bristol Regional Medical Center
+0.9948717948717949,0.0,"2400 Poplar Ave 501, Memphis, TN 38112",Christ Community Health Services Women's Center,"2400 Poplar Ave #501, Memphis, TN 38112",Christ Community Health Services Women's Center
+0.9948717948717949,0.2,"4201 N Dale Mabry Hwy, Tampa, FL 33607",Hillsborough County Dept of Health (Raymond James Stadium),"4201 N Dale Mabry Hwy., Tampa, FL 33607",Raymond James Stadium
+0.9948717948717949,0.0,"7495 W 29th Ave, Wheat Ridge, CO 80033",STRIDE CHC - JeffCo Family Health Services Center,"7495 W 29th Ave, Wheat Ridge, CO  80033",STRIDE CHC - Jeffco Family Health Services Center
+0.9948717948717949,0.1,"1501 W Elk Ave, Elizabethton, TN 37643",Sycamore Shoals Hospital,"1501 W. Elk Ave, Elizabethton, TN 37643",Sycamore Shoals Hospital
+0.995,0.0,"2500 Hospital Dr, Martinsburg, WV 25401",Berkeley Medical Center,"2500 Hospital Dr., Martinsburg, WV 25401",Berkeley Medical Center
+0.9951219512195122,0.0,"449 Kapahulu Ave 104, Honolulu, HI 96815",Queen’s Island Urgent Care-Kapahulu,"449 Kapahulu Ave #104, Honolulu, HI 96815",Queens Island Urgent Care- Kapahulu
+0.9952380952380953,0.0,"6125 W Sahara Ave 1B, Las Vegas, NV 89146",Sahara West Urgent Care,"6125 W Sahara Ave #1B, Las Vegas, NV 89146",Sahara West Urgent Care & Wellness
+0.9952380952380953,0.1,"347 Don Shula Dr, Miami Gardens, FL 33056",FEMA/Nat'l Guard/FL Dept of Health (Hard Rock Stadium),"347 Don Shula Dr., Miami Gardens, FL 33056",Hard Rock Stadium
+0.9958333333333332,0.0,"5850 Landerbrook Dr, Mayfield Heights, OH 44124",University Hospitals Landerbrook Mayfield Heights,"5850 Landerbrook Dr., Mayfield Heights, OH 44124",University Hospitals Drive Thru COVID-19 Testing Site
+0.9958333333333332,0.0,"500 S Mt Olive St 200, Siloam Springs, AR 72761",Siloam Springs Community Clinic,"500 S Mt Olive St #200, Siloam Springs, AR 72761",Community Clinic Siloam Springs Medical
+1.0,0.0,"1 Jarrett White Rd, Medical Center, HI 96859",Tripler Army Medical Center,"1 Jarrett White Rd, Medical Center, HI 96859",Tripler Army Medical Center
+1.0,0.0,"922 Highland Ave, Needham, MA 02494",CareWell Urgent Care-Needham,"922 Highland Ave, Needham, MA 02494",CareWell Needham
+1.0,1.4,"2384 N Memorial Dr, Lancaster, OH 43130",Fairfield Medical Center River Valley Campus - Emergency Department,"2384 N Memorial Dr, Lancaster, OH 43130",Fairfield Medical Center - River Valley Campus
+1.0,0.0,"2478 Nashville Hwy Suite A, Columbia, TN 38401",Maury Regional Urgent Care North Columbia,"2478 Nashville Hwy Suite A, Columbia, TN 38401",Maury Regional Urgent Care North Columbia
+1.0,0.0,"1212 Liggett Ave, Reading, PA 19611",Premier Women's Health - Tower Health Medical Group,"1212 Liggett Ave, Reading, PA 19611",Reading Hospital
+1.0,0.1,"6570 Bruton Smith Blvd, Concord, NC 28027",zMax Dragway (Atrium Health),"6570 Bruton Smith Blvd, Concord, NC 28027",ZMax Dragway and Atrium Health
+1.0,0.1,"2818 Neuse Blvd, New Bern, NC 28562",Craven County Health Department,"2818 Neuse Blvd, New Bern, NC 28562",Craven County Health Department
+1.0,6.9,"1429 N Quincy St, Arlington, VA 22207",Virginia Hospital Center (VHC),"1429 N Quincy St, Arlington, VA 22207",Virginia Hospital Center’s Sample Collection Site
+1.0,0.1,"3900 Broadway, Everett, WA 98201",Everett Memorial Stadium,"3900 Broadway, Everett, WA 98201",Everett Memorial Stadium
+1.0,0.1,"1800 Orleans St, Baltimore, MD 21287",John's Hopkins Hospital,"1800 Orleans St, Baltimore, MD 21287",Johns Hopkins Hospital
+1.0,0.1,"4801 Beckner Rd, Santa Fe, NM 87507",Presbyterian Sante Fe Medical Center,"4801 Beckner Rd, Santa Fe, NM 87507",Presbyterian Santa Fe Medical Center
+1.0,0.0,"969 Frayser Blvd, Memphis, TN 38127",Christ Community Health Services Frayser Health Center,"969 Frayser Blvd, Memphis, TN 38127",Christ Community Health Services Frayser Health Center
+1.0,0.0,"2569 Douglass Ave, Memphis, TN 38114",Christ Community Health Services Orange Mound Health Center,"2569 Douglass Ave, Memphis, TN 38114",Christ Community Health Services Orange Mound Health Center
+1.0,0.0,"3481 Austin Peay Hwy, Memphis, TN 38128",Christ Community Health Services Raleigh Health Center,"3481 Austin Peay Hwy, Memphis, TN 38128",Christ Community Health Services Raleigh Health Center
+1.0,0.0,"364 S Front St, Memphis, TN 38103",901 Health and Wellness,"364 S Front St, Memphis, TN 38103",901 Health and Wellness
+1.0,0.0,"147 Lake St, Newburgh, NY 12550",Cornerstone Medical Center in Newburgh,"147 Lake St, Newburgh, NY 12550",Cornerstone Medical Center Curbside Testing Center
+1.0,0.0,"600 Rhode Island Ave, Providence, RI 02908",Rhode Island College,"600 Rhode Island Ave, Providence, RI 02908",Rhode Island College
+1.0,1.9,"25500 Point Lookout Rd, Leonardtown, MD 20650",MedStar St. Mary’s Hospital,"25500 Point Lookout Rd, Leonardtown, MD 20650",MedStar St. Mary’s Hospital
+1.0,0.1,"300 Main St, Lewiston, ME 04240",Central Maine Medical Center Emergency Department,"300 Main St, Lewiston, ME 04240",Central Maine Medical Center
+1.0,0.0,"259 E Erie St, Chicago, IL 60611",Northwestern Memorial Hospital Lavin Family Pavilion,"259 E Erie St, Chicago, IL 60611",Northwestern Medicine Lavin Family Pavilion
+1.0,0.1,"111 Franklin health commons, Farmington, ME 04938",Franklin Memorial Hospital,"111 Franklin health commons, Farmington, ME 04938",Franklin Memorial Hospital
+1.0,1.7,"137 W North Ave, Northlake, IL 60164",Walmart (Parking Lot),"137 W North Ave, Northlake, IL 60164",Walmart (Parking Lot)
+1.0,0.0,"5140 N California Ave, Chicago, IL 60625",Swedish Hospital,"5140 N California Ave, Chicago, IL 60625",Swedish Hospital
+1.0,0.1,"2669 N Scenic Dr, Alamogordo, NM 88310",Gerald Champion Regional Medical Center Satellite Lab,"2669 N Scenic Dr, Alamogordo, NM 88310",Gerald Champion Regional Medical Center
+1.0,0.0,"903 Randolph St, Thomasville, NC 27360",Novant Health,"903 Randolph St, Thomasville, NC 27360",Thomasville Screening Center
+1.0,0.0,"50 Union St, Ellsworth, ME 04605",Northern Light Maine Coast Hospital,"50 Union St, Ellsworth, ME 04605",Northern Light Maine Coast Hospital - Drive Through COVID-19 Testing Center
+1.0,0.1,"1775 Dempster Street, Park Ridge, IL 60068",Advocate Lutheran General in Park Ridge,"1775 Dempster Street, Park Ridge, IL 60068",Advocate Lutheran General Hospital
+1.0,0.0,"2000 Brookside Dr, Kingsport, TN 37660",Indian Path Community Hospital,"2000 Brookside Dr, Kingsport, TN 37660",Indian Path Community Hospital
+1.0,0.2,"2030 Temple Hill Rd, Erwin, TN 37650",Unicoi Co. Hospital,"2030 Temple Hill Rd, Erwin, TN 37650",Unicoi Co. Hospital
+1.0,0.0,"11 Elliott Barker Ln, Angel Fire, NM 87710",Moreno Valley Healthcare,"11 Elliott Barker Ln, Angel Fire, NM 87710",South Central Colfax County - Moreno Valley Healthcare
+1.0,0.0,"356 9th St, Cimarron, NM 87714",Cimarron Healthcare Clinic,"356 9th St, Cimarron, NM 87714",Cimarron Healthcare Clinic
+1.0,0.0,"200 Kennedy Memorial Dr, Waterville, ME 04901",Northern Light Inland Hospital,"200 Kennedy Memorial Dr, Waterville, ME 04901",Northern Light Inland Hospital
+1.0,0.1,"893 Delaware St, Indianapolis, IN 46225",Eli Lilly and Company Corporate Center,"893 Delaware St, Indianapolis, IN 46225",Eli Lilly Drive-Thru Testing Site
+1.0,0.2,"840 Cherokee Trail, Copperhill, TN 37317",Polk County Copper Basin Center,"840 Cherokee Trail, Copperhill, TN 37317",Polk Copper Basin Center
+1.0,0.1,"300 Med Tech Pkwy, Johnson City, TN 37604",Franklin Woods Community Hospital,"300 Med Tech Pkwy, Johnson City, TN 37604",Franklin Woods Community Hospital
+1.0,0.0,"35 Miles St, Damariscotta, ME 04543",LincolnHealth,"35 Miles St, Damariscotta, ME 04543",LincolnHealth -Miles Memorial Hospital - Urgent Care
+1.0,0.1,"2060 Sam Rittenberg Blvd, Charleston, SC 29407",MUSC Health West Ashley Medical Pavilion,"2060 Sam Rittenberg Blvd, Charleston, SC 29407",MUSC Health West Ashley Medical Pavilion
+1.0,0.0,"1500 NY-9D, Wappingers Falls, NY 12590",Intermodal Center at Dutchess Stadium,"1500 NY-9D, Wappingers Falls, NY 12590",Intermodal Center at Dutchess Stadium
+1.0,0.1,"2601 W Ave N, San Angelo, TX 76909",Shannon Medical Center at Angelo State University,"2601 W Ave N, San Angelo, TX 76909","Angelo State University, Foster Field baseball stadium parking lot"
+1.0,0.0,"800 W Meeting St, Lancaster, SC 29720",MUSC Health - Lancaster,"800 W Meeting St, Lancaster, SC 29720",MUSC Health Lancaster Medical Center
+1.0,0.0,"315 Mocksville Ave, Salisbury, NC 28144",Novant Health,"315 Mocksville Ave, Salisbury, NC 28144",Salisbury Screening Center
+1.0,0.1,"46 Fairview Ave, Skowhegan, ME 04976",Redington-Fairview General Hospital,"46 Fairview Ave, Skowhegan, ME 04976",Redington-Fairview General Hospital
+1.0,0.1,"400 East Ave, Warwick, RI 02886",Community College of Rhode Island - Knight Campus,"400 East Ave, Warwick, RI 02886",Community College of Rhode Island - Warwick
+1.0,0.0,"4150 N 1st St, San Jose, CA 95134",El Camino Health Urgent Care,"4150 N 1st St, San Jose, CA 95134",El Camino Health Urgent Care - San Jose
+1.0,0.1,"863 Nazareth Pike, Nazareth, PA 18064",LVHN COVID-19 Assess and Test–Nazareth,"863 Nazareth Pike, Nazareth, PA 18064",LVHN COVID-19 Assess and Test–Nazareth
+1.0,0.1,"1 Citizens Bank Way, Philadelphia, PA 19148",Citizens Bank Park,"1 Citizens Bank Way, Philadelphia, PA 19148",Citizens Bank Park
+1.0,0.0,"2500 Victory Ave, Dallas, TX 75219",American Airlines Center - Parking Lot,"2500 Victory Ave, Dallas, TX 75219",American Airlines Center - Parking Lot E
+1.0,0.0,"9191 S Polk St, Dallas, TX 75232",Ellis Davis Field House,"9191 S Polk St, Dallas, TX 75232",Jesse Owens Memorial Complex - Ellis Davis Field House
+1.0,0.1,"16901 Lakeside Hills Ct, Omaha, NE 68130",CHI Health Lakeside,"16901 Lakeside Hills Ct, Omaha, NE 68130",CHI Health Lakeside
+1.0,0.0,"500 Diamond Dr, Lake Elsinore, CA 92530",Diamond Stadium,"500 Diamond Dr, Lake Elsinore, CA 92530",Diamond Stadium
+1.0,0.1,"4300 Rose Dr, Yorba Linda, CA 92886",Providence Health Systems,"4300 Rose Dr, Yorba Linda, CA 92886",St. Joseph Heritage Medical Center
+1.0,0.0,"155 Glasson Way, Grass Valley, CA 95945",Sierra Nevada Memorial Hospital,"155 Glasson Way, Grass Valley, CA 95945",Sierra Nevada Memorial Hospital
+1.0,0.1,"1301 Grundman Blvd, Nebraska City, NE 68410",CHI Health St. Mary's,"1301 Grundman Blvd, Nebraska City, NE 68410",CHI Health St Mary's
+1.0,0.0,"11111 S 84th St, Papillion, NE 68046",CHI Health Midlands,"11111 S 84th St, Papillion, NE 68046",CHI Health Midlands
+1.0,0.0,"8431 Fredericksburg Rd, San Antonio, TX 78229",South Texas Medical Center,"8431 Fredericksburg Rd, San Antonio, TX 78229",South Texas Medical Center Drive-Thru Testing
+1.0,0.1,"2500 Bellevue Medical Center Dr, Bellevue, NE 68123",Bellevue Hospital,"2500 Bellevue Medical Center Dr, Bellevue, NE 68123",Nebraska Medicine Bellevue Medical Center
+1.0,0.0,"1059 Canal St, Manchester, NH 03101",New Hampshire National Guard Armory,"1059 Canal St, Manchester, NH 03101",National Guard State Armory
+1.0,0.2,"1 Medical Center Dr, Lebanon, NH 03766",Dartmouth-Hitchcock Medical Center,"1 Medical Center Dr, Lebanon, NH 03766",Dartmouth-Hitchcock Medical Center laboratory
+1.0,0.0,"1200 Old York Rd, Abington, PA 19001",Abington Hospital - Jefferson Health,"1200 Old York Rd, Abington, PA 19001",Abington Hospital
+1.0,0.0,"28270 Huntwood Ave, Hayward, CA 94544",Hayward Fire Station #7,"28270 Huntwood Ave, Hayward, CA 94544",Hayward Fire Station #7
+1.0,0.0,"10680 Del Mar Pkwy, Aurora, CO 80010",STRIDE CHC - Aurora Health & Wellness Plaza,"10680 Del Mar Pkwy, Aurora, CO 80010",Aurora Health & Wellness Plaza
+1.0,0.0,"1111 S Irving Heights Dr, Irving, TX 75060",MD Family Clinic - Irving Heights Location,"1111 S Irving Heights Dr, Irving, TX 75060",MD Family Clinic - Irving Heights Location
+1.0,0.0,"1743 Redstone Center Dr, Park City, UT 84098",Redstone Health Center,"1743 Redstone Center Dr, Park City, UT 84098",Redstone Health Center
+1.0,0.0,"10058 Long Point Rd, Houston, TX 77055",Clinicas Mi Doctor,"10058 Long Point Rd, Houston, TX 77055",Clinicas Mi Doctor
+1.0,0.1,"5126 W Daybreak Pkwy, South Jordan, UT 84009",South Jordan Health Center,"5126 W Daybreak Pkwy, South Jordan, UT 84009",South Jordan Health Center
+1.0,0.6,"1000 Morris Ave, Union, NJ 07083",Kean University,"1000 Morris Ave, Union, NJ 07083",Kean University
+1.0,0.1,"850 Greenfield Rd, Lancaster, PA 17601",Pennsylvania College of Health Sciences,"850 Greenfield Rd, Lancaster, PA 17601",Pennsylvania College of Health Sciences
+1.0,0.1,"555 N Duke St, Lancaster, PA 17602",Lancaster General Health,"555 N Duke St, Lancaster, PA 17602",Penn Medicine Lancaster General Hospital
+1.0,0.0,"1280 E Stringham Ave, Salt Lake City, UT 84106",Sugar House Health Center,"1280 E Stringham Ave, Salt Lake City, UT 84106",Sugar House Health Center
+1.0,0.1,"1525 2100 S, Salt Lake City, UT 84119",Redwood Health Center,"1525 2100 S, Salt Lake City, UT 84119",Redwood Health Center
+1.0,0.1,"334 Carlisle Ave, York, PA 17404",York Fairgrounds - WellSpan Testing Site,"334 Carlisle Ave, York, PA 17404",York Expo Center
+1.0,0.0,"501 Marlins Way, Miami, FL 33125",Marlins Park,"501 Marlins Way, Miami, FL 33125",Marlins Park
+1.0,0.0,"1000 Harrington St, Mt Clemens, MI 48043",Mclaren Macomb Hospital,"1000 Harrington St, Mt Clemens, MI 48043",McLaren Macomb hospital
+1.0,0.1,"16700 Jog Rd, Delray Beach, FL 33446",South County Civic Center,"16700 Jog Rd, Delray Beach, FL 33446",South County Civic Center COVID 19 Testing site
+1.0,0.0,"3200 W De Soto St, Pensacola, FL 32505",Community Health Northwest Florida (Brownsville Community Center),"3200 W De Soto St, Pensacola, FL 32505",Brownsville Community Center
+1.0,0.1,"1000 Water St, Jacksonville, FL 32204",Prime Osborn Convention Center,"1000 Water St, Jacksonville, FL 32204",Prime F. Osborn III Convention Center
+1.0,0.1,"1099 S Beacon Blvd, Grand Haven, MI 49417",North Ottawa Community Health System,"1099 S Beacon Blvd, Grand Haven, MI 49417",North Ottawa Community Health System
+1.0,0.0,"425 University Blvd, Round Rock, TX 78665",Baylor Scott & White Clinic – Round Rock 425 University,"425 University Blvd, Round Rock, TX 78665",Baylor Scott & White Clinic - Round Rock
+1.0,0.0,"597 W 11th St, Panama City, FL 32401",Main Location - Ullman Building,"597 W 11th St, Panama City, FL 32401",Bay County Department of Health
+1.0,0.1,"266 Joule St, Alcoa, TN 37701",East Tennessee Medical Group,"266 Joule St, Alcoa, TN 37701",East Tennessee Medical Group
+1.0,0.2,"100 Ter Heun Dr, Falmouth, MA 02540",Falmouth Hospital,"100 Ter Heun Dr, Falmouth, MA 02540",Falmouth Hospital - Triage Tent
+1.0,0.1,"342 Frey St, Ashland City, TN 37015",Family Health Center of Ashland City PLLC,"342 Frey St, Ashland City, TN 37015",Family Health Center of Ashland City PLLC
+1.0,0.1,"165 N University Ave, Farmington, UT 84025",Farmington Health Center,"165 N University Ave, Farmington, UT 84025",Farmington Health Center
+1.0,0.0,"3855 West Chester Pike, Newtown Square, PA 19073",Main Line Health - Newton Square,"3855 West Chester Pike, Newtown Square, PA 19073",Main Line Health - Newtown Square
+1.0,0.1,"951 N Broad St, Tazewell, TN 37879",Tazewell Drug and Express Care,"951 N Broad St, Tazewell, TN 37879",Tazewell Drug and Express Care
+1.0,0.7,"935 N 1000 W, Tremonton, UT 84337",Bear River Clinic,"935 N 1000 W, Tremonton, UT 84337",Bear River Clinic
+1.0,0.0,"1400 E College Ave, McAlester, OK 74501",Pittsburg County Health Department,"1400 E College Ave, McAlester, OK 74501",Oklahoma Health Department
+1.0,0.0,"2104 Dayton Ave, Nashville, TN 37210",Vanderbilt Medical Center,"2104 Dayton Ave, Nashville, TN 37210",Vanderbilt Drive Thru Testing Facility
+1.0,0.0,"3702 2nd Ave, Columbus, GA 31904",Mercy Med of Columbus,"3702 2nd Ave, Columbus, GA 31904",MercyMed of Columbus
+1.0,0.0,"100 Hospital Dr, Bennington, VT 05201",Southwestern Vermont Medical Center,"100 Hospital Dr, Bennington, VT 05201",Southwestern Vermont Health Care
+1.0,0.1,"1420 Tusculum Blvd, Greeneville, TN 37745",Greeneville Community Hospital East,"1420 Tusculum Blvd, Greeneville, TN 37745",Greeneville Community Hospital East
+1.0,0.1,"851 Locust St, Rogersville, TN 37857",Hawkins Co. Memorial Hospital,"851 Locust St, Rogersville, TN 37857",Hawkins County Memorial Hospital
+1.0,0.0,"232 S Woods Mill Rd, Chesterfield, MO 63017",Saint Luke’s Hospital,"232 S Woods Mill Rd, Chesterfield, MO 63017",St. Lukes Hospital - Drive-Through Covid-19 Testing Site
+1.0,0.0,"1199 Prince Ave, Athens, GA 30606",Piedmont Athens Regional,"1199 Prince Ave, Athens, GA 30606",Piedmont Athens Regional
+1.0,0.0,"7221 Sallie Mood Dr, Savannah, GA 31406",Jennifer Ross Soccer Complex,"7221 Sallie Mood Dr, Savannah, GA 31406",Jennifer Ross Soccer Complex
+1.0,0.1,"16942 GA-67, Statesboro, GA 30458",Kiwanis Ogeechee Fair,"16942 GA-67, Statesboro, GA 30458",Ogeechee Fairgrounds
+1.0,4.5,"91-2141 Fort Weaver Rd, Ewa Beach, HI 96706",The Queen's Medical Center-West Oahu Triage Center,"91-2141 Fort Weaver Rd, Ewa Beach, HI 96706",Queens Medical Center- West Oahu
+1.0,29.9,"11760 Baltimore Ave, Beltsville, MD 20705",MDOT MVA Vehicle Inspection/Emission Center: Beltsville,"11760 Baltimore Ave, Beltsville, MD 20705",Beltsville Vehicle Emissions Inspection Program (VEIP) station
+1.0,0.1,"1301 Punchbowl St, Honolulu, HI 96813",The Queen's Medical Center-Punchbowl Triage Center,"1301 Punchbowl St, Honolulu, HI 96813",Queens Medical Center


### PR DESCRIPTION
Closes: #35

 ## Goal
Resolve the following issues with the CAC comparison output:

- Eliminate sites for which we have only partial addresses (the address matching algorithm isn't useful in this case)
- Eliminate sites for states that CAC doesn't cover (Puerto Rico, as far as I know)
- Include facility name for both our data & CAC's in the output
- Improve headers
- Sort from lowest to highest likelihood match

 ## Approach
1. Modified the CAC class to address all of these issues.
