### PR TITLE
40 ignore deleted cac data

### DIFF
--- a/lib/test_sites/cac.rb
+++ b/lib/test_sites/cac.rb
@@ -17,6 +17,8 @@ module TestSites
 
     def self.cac_data
       TestSites::CACClient.new.locations.map do |location|
+        next if location.deleted_on.present?
+
         if location.location_address_region.blank?
           address = StreetAddress::US.parse(location.location_address_street)
           location.location_address_region = address&.state


### PR DESCRIPTION
Closes: #40

 ## Goal
Ignore deleted CAC locations.

 ## Approach
1. Skip the record if `:deleted_on` is defined.
2. Refactor to promote the connection to an instance variable since the connection, not the endpoint, is what's reused.

## Notes
This change isn't covered because the existing test:
1. runs against production data.
2. doesn't run on CI anyway.