### PR TITLE
Use `filter_map` to avoid nil in cac_data

### DIFF
--- a/lib/test_sites/cac.rb
+++ b/lib/test_sites/cac.rb
@@ -16,7 +16,7 @@ module TestSites
     end
 
     def self.cac_data
-      TestSites::CACClient.new.locations.map do |location|
+      TestSites::CACClient.new.locations.filter_map do |location|
         next if location.deleted_on.present?
 
         if location.location_address_region.blank?


### PR DESCRIPTION
 ## Goal
Running into bug with `all_hours` trying to access hash value on nil. When we added ignore when `deleted_on` is present, we inadvertently introduced `nil`s at those spots instead. `Enumerable#filter_map` rejects falsey return values.

 ## Approach
1. Found a "nil has no such method" error when running tests and traced back to this method.

 ## Deployment
N/A
