### PR TITLE
Add pry for better debugging

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -20,12 +20,12 @@ gem 'StreetAddress', '~> 1.0', '>= 1.0.6', require: 'street_address'
 gem 'xsv', '~> 0.3.11'
 
 group :development do
+  gem 'pry'
   gem 'rubocop'
 end
 
 group :development, :test do
   gem 'faraday-detailed_logger', '~> 2.3'
-
   gem 'minitest', '~> 5.14'
   gem 'rake', '~> 13.0', '>= 13.0.1'
 end

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -11,6 +11,7 @@ GEM
       tzinfo (~> 1.1)
       zeitwerk (~> 2.2)
     ast (2.4.0)
+    coderay (1.1.2)
     concurrent-ruby (1.1.6)
     faraday (1.0.1)
       multipart-post (>= 1.2, < 3)
@@ -30,6 +31,7 @@ GEM
       concurrent-ruby (~> 1.0)
     jaro_winkler (1.5.4)
     json (2.3.0)
+    method_source (1.0.0)
     minitest (5.14.0)
     multi_json (1.14.1)
     multipart-post (2.1.1)
@@ -37,6 +39,9 @@ GEM
     parallel (1.19.1)
     parser (2.7.1.1)
       ast (~> 2.4.0)
+    pry (0.13.1)
+      coderay (~> 1.1)
+      method_source (~> 1.0)
     rainbow (3.0.0)
     rake (13.0.1)
     redis (4.1.3)
@@ -78,6 +83,7 @@ DEPENDENCIES
   jaro_winkler (~> 1.4)
   json (~> 2.3)
   minitest (~> 5.14)
+  pry
   rake (~> 13.0, >= 13.0.1)
   redis (~> 4.1, >= 4.1.3)
   rubocop

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -6,6 +6,7 @@ load 'test_sites.rb' unless defined?(TestSites)
 load 'models.rb' unless defined?(Models)
 
 require 'minitest/autorun'
+require 'pry'
 
 class TestSitesTestCase < Minitest::Test
 end


### PR DESCRIPTION
 ## Goal
Add `pry` for better debugging: breakpoints can now be added anywhere in the code with `binding.pry`.