### PR TITLE
Fix forbidden attributes error

### DIFF
--- a/lib/models/cac_location.rb
+++ b/lib/models/cac_location.rb
@@ -53,8 +53,8 @@ class CACLocation
   #
   # @return [Array] all CACLocations from the API
   def self.all_from_api
-    TestSites::CAC.cac_data.each_with_object([]) do |json, locations|
-      locations << CACLocation.new(json.permit(ATTRIBUTES))
+    TestSites::CAC.cac_data.map do |hash|
+      CACLocation.new(hash)
     end
   end
 

--- a/lib/test_sites/no_warning_mash.rb
+++ b/lib/test_sites/no_warning_mash.rb
@@ -7,5 +7,17 @@ module TestSites
   # overridden methods.
   class NoWarningMash < Hashie::Mash
     disable_warnings
+
+    def respond_to_missing?(method_name, *args)
+      return false if method_name == :permitted?
+
+      super
+    end
+
+    def method_missing(method_name, *args)
+      raise ArgumentError if method_name == :permitted?
+
+      super
+    end
   end
 end


### PR DESCRIPTION
Closes: #50 

 ## Goal
Fix ForbiddenAttributesError that's triggered when creating a CACLocation from a Hashie Mash of attributes.

 ## Approach
1. override `respond_to_missing?` and `method_missing` in NoWarningMash to prevent NoWarningMash from responding to :permitted?
