### PR TITLE
Add arcgis_location to CACLocation

### DIFF
--- a/lib/models/cac_location.rb
+++ b/lib/models/cac_location.rb
@@ -53,7 +53,7 @@ class CACLocation
   #
   # @return [Array] all CACLocations from the API
   def self.all_from_api
-    arcgis_locations = ArcGISClient.all_features
+    arcgis_locations = ArcGISClient.locations
     TestSites::CAC.cac_data.map do |hash|
       CACLocation.new(hash).tap do |location|
         location.arcgis_location = arcgis_locations[location.arcgis_global_id]

--- a/lib/models/cac_location.rb
+++ b/lib/models/cac_location.rb
@@ -13,7 +13,7 @@ class CACLocation
   include ActiveModel::Model
 
   ATTRIBUTES =
-    %i[additional_information_for_patients created_on
+    %i[arcgis_location additional_information_for_patients created_on
        data_source deleted_on external_location_id geojson
        is_collecting_samples is_collecting_samples_by_appointment_only
        is_collecting_samples_for_others is_collecting_samples_onsite
@@ -53,8 +53,11 @@ class CACLocation
   #
   # @return [Array] all CACLocations from the API
   def self.all_from_api
+    arcgis_locations = ArcGISClient.all_features
     TestSites::CAC.cac_data.map do |hash|
-      CACLocation.new(hash)
+      CACLocation.new(hash).tap do |location|
+        location.arcgis_location = arcgis_locations[location.esri_global_id]
+      end
     end
   end
 

--- a/lib/models/cac_location.rb
+++ b/lib/models/cac_location.rb
@@ -56,7 +56,7 @@ class CACLocation
     arcgis_locations = ArcGISClient.all_features
     TestSites::CAC.cac_data.map do |hash|
       CACLocation.new(hash).tap do |location|
-        location.arcgis_location = arcgis_locations[location.esri_global_id]
+        location.arcgis_location = arcgis_locations[location.arcgis_global_id]
       end
     end
   end
@@ -94,8 +94,8 @@ class CACLocation
 
   def storepoint_wed; end
 
-  def esri_global_id
-    @esri_global_id ||=
+  def arcgis_global_id
+    @arcgis_global_id ||=
       if external_location_id.present?
         global_id =
           JSON.parse(external_location_id).compact.find do |id|

--- a/lib/test_sites/arcgis_client.rb
+++ b/lib/test_sites/arcgis_client.rb
@@ -13,6 +13,13 @@ module TestSites
     # rubocop:disable Style/ClassVars
     @@connection = nil
 
+    def self.all_features
+      all['features'].each_with_object({}) do |arcgis_location, acc|
+        mash = NoWarningMash.new(arcgis_location['attributes'])
+        acc[mash.GlobalID] = mash
+      end
+    end
+
     # Returns all results from the ArcGIS API.
     #
     # @param options [Hash] query parameters (ignored!)

--- a/lib/test_sites/arcgis_client.rb
+++ b/lib/test_sites/arcgis_client.rb
@@ -13,13 +13,6 @@ module TestSites
     # rubocop:disable Style/ClassVars
     @@connection = nil
 
-    def self.all_features
-      all['features'].each_with_object({}) do |arcgis_location, acc|
-        mash = NoWarningMash.new(arcgis_location['attributes'])
-        acc[mash.GlobalID] = mash
-      end
-    end
-
     # Returns all results from the ArcGIS API.
     #
     # @param options [Hash] query parameters (ignored!)
@@ -33,20 +26,16 @@ module TestSites
       @@connection
     end
 
-    # Returns the first location from the ArcGIS API.
-    #
-    # @param options [Hash] query parameters (ignored!)
-    # @return [Hash] the first location's :attributes and :geometry
-    def self.first_location(options = {})
-      locations(options).first
-    end
-
     # Returns all locations from the ArcGIS API.
     #
     # @param options [Hash] query parameters (ignored!)
-    # @return [Array] :attributes and :geometry for all locations
+    # @return [Hash] keyed by ArcGIS ID, values contain attributes for the
+    # location.
     def self.locations(options = {})
-      all(options)['features']
+      all(options)['features'].each_with_object({}) do |arcgis_location, acc|
+        mash = NoWarningMash.new(arcgis_location['attributes'])
+        acc[mash.GlobalID] = mash
+      end
     end
 
     def initialize

--- a/test/models/cac_location_test.rb
+++ b/test/models/cac_location_test.rb
@@ -136,8 +136,8 @@ class CACLocationTest < TestSitesTestCase
   end
   # rubocop:enable Metrics/AbcSize, Metrics/MethodLength
 
-  def test_esri_global_id
-    assert storepoint_esri.esri_global_id ==
+  def test_arcgis_global_id
+    assert storepoint_esri.arcgis_global_id ==
            '81e0292d-65fc-4fed-9cc8-5878719598e3'
   end
 

--- a/test/unit/arcgis_client_test.rb
+++ b/test/unit/arcgis_client_test.rb
@@ -7,12 +7,7 @@ class ArcGISClientTest < TestSitesTestCase
     refute_empty TestSites::ArcGISClient.all
   end
 
-  def test_first_location
-    assert_equal TestSites::ArcGISClient.first_location.keys,
-                 %w[attributes geometry]
-  end
-
   def test_locations
-    assert_instance_of Array, TestSites::ArcGISClient.locations
+    assert_instance_of Hash, TestSites::ArcGISClient.locations
   end
 end


### PR DESCRIPTION
Closes: #39

 ## Goal
Adds GiSCorps attributes to CACLocation.

## Approach
1. Match records returned by `ArcGISClient` to `CACLocation` records by ID. When a `CACLocation` is found to have a corresponding `ArcGISClient` attribute, make that data available from the `arcgis_location` attribute of `CACLocation`.

