### PR TITLE
15 Gamify documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,7 @@
 # StorePoint COVID-19 Testing Sites
 
 [![Code Climate](https://codeclimate.com/github/Spark-Bio/covid-storepoint.png)](https://codeclimate.com/github/Spark-Bio/covid-storepoint)
+[![Inline docs](http://inch-ci.org/github/Spark-Bio/covid-storepoint.svg?branch=master)](http://inch-ci.org/github/Spark-Bio/covid-storepoint)
 
 Utilities for generating a CSV file of COVID-19 testing sites in the format required by [StorePoint](https://storepoint.co/dashboard/help).
 


### PR DESCRIPTION
Closes: #15

 ## Goal
Incentivize documentation by adding [Inch-CI](https://inch-ci.org) to the mix and displaying their results as a badge in the README.

 ## Approach
1. Follow their [install instructions](https://inch-ci.org/help/webhook).
2. Add their badge.
