### PR TITLE
44 refactor geocoding rebased

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -32,6 +32,11 @@ task :geocode do
   TestSites::Geocoder.new.process(TestSites::Source.new)
 end
 
+task :geocode_cac_locations do
+  load 'lib/test_sites.rb' unless defined?(TestSites)
+  TestSites::Geocoder.new.process(CACLocation.all_from_api)
+end
+
 desc 'Check that the hour listings in the source file all parse correctly'
 task :check_hours do
   load 'lib/test_sites.rb' unless defined?(TestSites)

--- a/Rakefile
+++ b/Rakefile
@@ -29,7 +29,7 @@ end
 
 task :geocode do
   load 'lib/test_sites.rb' unless defined?(TestSites)
-  TestSites::Geocoder.new.process
+  TestSites::Geocoder.new.process(TestSites::Source.new)
 end
 
 desc 'Check that the hour listings in the source file all parse correctly'

--- a/lib/models/cac_location.rb
+++ b/lib/models/cac_location.rb
@@ -71,8 +71,8 @@ class CACLocation
   end
 
   def address
-    [location_address_street, location_address_locality, location_address_region,
-     location_address_postal_code].join(' ')
+    [location_address_street, location_address_locality,
+     location_address_region, location_address_postal_code].join(' ')
   end
 
   def storepoint_country; end

--- a/lib/models/cac_location.rb
+++ b/lib/models/cac_location.rb
@@ -79,6 +79,10 @@ class CACLocation
     locations.map(&:to_storepoint)
   end
 
+  def address
+    location_address_street
+  end
+
   def street
     @componentized_us_address&.street || location_address_street
   end

--- a/lib/models/cac_location.rb
+++ b/lib/models/cac_location.rb
@@ -70,6 +70,11 @@ class CACLocation
     locations.map(&:to_storepoint)
   end
 
+  def address
+    [location_address_street, location_address_locality, location_address_region,
+     location_address_postal_code].join(' ')
+  end
+
   def storepoint_country; end
 
   def storepoint_description

--- a/lib/test_sites/componentized_us_address.rb
+++ b/lib/test_sites/componentized_us_address.rb
@@ -15,25 +15,25 @@ module TestSites
     end
 
     def city
-      @geocoder_result.city
+      @geocoder_result&.city
     end
 
     def state
-      @geocoder_result.state
+      @geocoder_result&.state
     end
 
     def zip
-      @geocoder_result.postcode
+      @geocoder_result&.postcode
     end
 
     private
 
     def street_addresss
-      if @geocoder_result.street_number && @geocoder_result.route
+      if @geocoder_result&.street_number && @geocoder_result&.route
         [
-          @geocoder_result.street_number,
-          @geocoder_result.route,
-          @geocoder_result.subpremise
+          @geocoder_result&.street_number,
+          @geocoder_result&.route,
+          @geocoder_result&.subpremise
         ].compact.join(' ')
       else
         street_address_fallback
@@ -41,11 +41,11 @@ module TestSites
     end
 
     def intersection
-      @geocoder_result.intersection
+      @geocoder_result&.intersection
     end
 
     def street_address_fallback
-      if @geocoder_result.formatted_address
+      if @geocoder_result&.formatted_address
         address = StreetAddress::US.parse(implicit_us_address)
         if address&.number && address&.street && address&.street_type
           "#{address.number} #{address.street} #{address.street_type}"
@@ -54,7 +54,7 @@ module TestSites
     end
 
     def implicit_us_address
-      @geocoder_result.formatted_address.gsub(/, USA?/, '')
+      @geocoder_result&.formatted_address.gsub(/, USA?/, '')
     end
   end
 end

--- a/lib/test_sites/componentized_us_address.rb
+++ b/lib/test_sites/componentized_us_address.rb
@@ -54,7 +54,7 @@ module TestSites
     end
 
     def implicit_us_address
-      @geocoder_result&.formatted_address.gsub(/, USA?/, '')
+      @geocoder_result&.formatted_address&.gsub(/, USA?/, '')
     end
   end
 end

--- a/lib/test_sites/geocoder.rb
+++ b/lib/test_sites/geocoder.rb
@@ -12,6 +12,8 @@ module TestSites
       geocoder_results.update(results)
     end
 
+    private
+
     # rubocop:disable Metrics/AbcSize, Metrics/MethodLength
     def geocode
       TestSites.logger.debug "*** Geocoding #{source.size} listings"

--- a/lib/test_sites/geocoder.rb
+++ b/lib/test_sites/geocoder.rb
@@ -20,17 +20,17 @@ module TestSites
 
       counters = Struct.new(:skipped, :successes, :exceptions).new(0, 0, 0)
       # rubocop:disable Style/MultilineBlockChain
-      locations.each_with_object({ successes: {}, exceptions: {} }) do |e, a|
-        next if e.address.nil? || geocoder_results.already_geocoded?(e.address)
+      locations.each_with_object({ successes: {}, exceptions: {} }) do |l, a|
+        next if l.address.nil? || geocoder_results.already_geocoded?(l.address)
 
         begin
-          TestSites.logger.debug "geocoding #{e.address}"
-          a[:successes][e.address] = geocode_address(e.address)
+          TestSites.logger.debug "geocoding #{l.address}"
+          a[:successes][l.address] = geocode_address(l.address)
           counters.successes += 1
-        rescue StandardError => err
-          TestSites.logger.debug "*** EXCEPTION for #{e.address}"
-          a[:exceptions][e.address] = { class: err.class.to_s,
-                                        message: err.message }
+        rescue StandardError => e
+          TestSites.logger.debug "*** EXCEPTION for #{l.address}"
+          a[:exceptions][l.address] = { class: e.class.to_s,
+                                        message: e.message }
           counters.exceptions += 1
         end
       end.tap do

--- a/lib/test_sites/geocoder.rb
+++ b/lib/test_sites/geocoder.rb
@@ -29,7 +29,7 @@ module TestSites
           counters.successes += 1
         rescue StandardError => e
           TestSites.logger.debug "*** EXCEPTION for #{l.address}"
-          a[:exceptions][l.address] = { class: e.class.to_s,
+          a[:exceptions][l.address] = { class_name: e.class.to_s,
                                         message: e.message }
           counters.exceptions += 1
         end

--- a/lib/test_sites/geocoder.rb
+++ b/lib/test_sites/geocoder.rb
@@ -27,10 +27,10 @@ module TestSites
           TestSites.logger.debug "geocoding #{e.address}"
           a[:successes][e.address] = geocode_address(e.address)
           counters.successes += 1
-        rescue StandardError => e
+        rescue StandardError => err
           TestSites.logger.debug "*** EXCEPTION for #{e.address}"
-          a[:exceptions][e.address] = { class: e.class.to_s,
-                                        message: e.message }
+          a[:exceptions][e.address] = { class: err.class.to_s,
+                                        message: err.message }
           counters.exceptions += 1
         end
       end.tap do

--- a/lib/test_sites/geocoder.rb
+++ b/lib/test_sites/geocoder.rb
@@ -31,7 +31,7 @@ module TestSites
           TestSites.logger.debug "*** EXCEPTION for #{e.address}"
           a[:exceptions][e.address] = { class: e.class.to_s,
                                         message: e.message }
-          counters.excpetions += 1
+          counters.exceptions += 1
         end
       end.tap do
         TestSites.logger.debug '*** Gecoder Results'

--- a/lib/test_sites/geocoder_client.rb
+++ b/lib/test_sites/geocoder_client.rb
@@ -13,6 +13,8 @@ module TestSites
       gmaps.geocode(address)
     end
 
+    private
+
     def gmaps
       @gmaps ||= GoogleMapsService::Client.new(key: GOOGLE_API_KEY_COVID)
     end

--- a/test/rake_test.rb
+++ b/test/rake_test.rb
@@ -19,6 +19,10 @@ class RakeTest < TestSitesTestCase
                                   'test/fixtures/cac_comparison.csv')
   end
 
+  def test_geocode_cac_locations
+    Rake.application.invoke_task 'geocode_cac_locations'
+  end
+
   def test_update_storepoint
     Rake.application.invoke_task 'update_storepoint'
     assert FileUtils.compare_file('data/store_point.csv',

--- a/test/rake_test.rb
+++ b/test/rake_test.rb
@@ -20,6 +20,8 @@ class RakeTest < TestSitesTestCase
   end
 
   def test_geocode_cac_locations
+    return if ENV['GITHUB_RUN_ID'] # skip integration test if running on github
+
     Rake.application.invoke_task 'geocode_cac_locations'
   end
 


### PR DESCRIPTION
Related to: #44 (item 1)

 ## Goal
Generalize `TestSites::Geocoder` to work with `CACLocations`.

 ## Approach
1. Refactor `TestSites::Geocoder#process` to accept location records
2. Test 1 with `CACLoation.all_from_api`.
3. Add coverage for 1 and 2.
4. Refactor `CACLoation.all_from_api` to use `ComponentizedUSAddress`.