### PR TITLE
32 coveralls token

### DIFF
--- a/.coveralls.yml
+++ b/.coveralls.yml
@@ -1,0 +1,1 @@
+repo_token: ENV['COVERALLS_REPO_TOKEN']

--- a/.coveralls.yml
+++ b/.coveralls.yml
@@ -1,1 +1,1 @@
-repo_token: ENV['COVERALLS_REPO_TOKEN']
+repo_token: PaYj62d5vnXVsViptd6tIYu48htoyCKxv

--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
+coverage
 data/cac_as_storepoint.csv
 data/cac_comparison.csv
 data/store_point.csv


### PR DESCRIPTION
Closes: #32

 ## Goal
Fix Coveralls integration.

 ## Approach
1. Added token to `.coveralls.yml` since adding it as a [secret](https://github.com/Spark-Bio/covid-storepoint/settings/secrets) doesn't work.
2. Ignored `coverage/`.
