### PR TITLE
59 zip

### DIFF
--- a/lib/models/cac_location.rb
+++ b/lib/models/cac_location.rb
@@ -56,7 +56,7 @@ class CACLocation
   # @return [Array] all CACLocations from the API
   def self.all_from_api
     geocoder_results = TestSites::GeocoderResults.new.filtered
-    arcgis_locations = ArcGISClient.locations
+    arcgis_locations = TestSites::ArcGISClient.locations
 
     TestSites::CAC.cac_data.map do |mash|
       CACLocation.new(mash).tap do |location|

--- a/lib/models/cac_location.rb
+++ b/lib/models/cac_location.rb
@@ -106,7 +106,7 @@ class CACLocation
   end
 
   def zip
-    @componentized_us_address&.zip || location_address_postal_code
+    "\"#{@componentized_us_address&.zip || location_address_postal_code}\""
   end
 
   def phone

--- a/test/models/cac_location_test.rb
+++ b/test/models/cac_location_test.rb
@@ -131,7 +131,7 @@ class CACLocationTest < TestSitesTestCase
     assert storepoint_attr[:address] == '550 First Avenue'
     assert storepoint_attr[:city] == 'New York'
     assert storepoint_attr[:state] == 'NY'
-    assert storepoint_attr[:postcode] == '10016'
+    assert storepoint_attr[:postcode] == '"10016"'
     assert storepoint_attr[:phone] == '347-377-3708'
     assert storepoint_attr[:website] ==
            'https://nyulangone.org/locations/tisch-hospital'


### PR DESCRIPTION
Closes: #59

 ## Goal
Prevent Excel from interpreting zip codes as numbers.

 ## Approach
1. Change `CACLocation#zip` to wrap its output in quotes.

 ## Notes
1. Using CSV's `force_quotes: true` doesn't work!
2. This solution makes the quotes visible in Excel, but there appears to be no other programmatic fix.
3. We could avoid the quotes by having users override Excel's typing when opening the file, but this seems more onerous.
