### PR TITLE
60 phone

### DIFF
--- a/lib/models/cac_location.rb
+++ b/lib/models/cac_location.rb
@@ -38,7 +38,7 @@ class CACLocation
     location_name: :name, storepoint_description: :description,
     street: :address, city: :city,
     state: :state, zip: :postcode,
-    storepoint_country: :country, location_contact_phone_covid: :phone,
+    storepoint_country: :country, phone: :phone,
     location_contact_url_main: :website, storepoint_email: :email,
     storepoint_mon: :monday, storepoint_tue: :tuesday,
     storepoint_wed: :wednesday, storepoint_thu: :thursday,

--- a/lib/models/cac_location.rb
+++ b/lib/models/cac_location.rb
@@ -109,6 +109,11 @@ class CACLocation
     @componentized_us_address&.zip || location_address_postal_code
   end
 
+  def phone
+    [location_contact_phone_covid, location_contact_phone_appointments,
+     location_contact_phone_main].compact.find(&:present?)
+  end
+
   def storepoint_country; end
 
   def storepoint_description

--- a/test/models/cac_location_test.rb
+++ b/test/models/cac_location_test.rb
@@ -110,6 +110,18 @@ class CACLocationTest < TestSitesTestCase
     'updated_on': 'Fri, 24 Apr 2020 12:50:49 GMT'
   }.freeze
 
+  def test_phone
+    location = CACLocation
+               .new(location_contact_phone_covid: 'covid',
+                    location_contact_phone_appointments: 'appointments',
+                    location_contact_phone_main: 'main')
+    assert location.phone == 'covid'
+    location.location_contact_phone_covid = nil
+    assert location.phone == 'appointments'
+    location.location_contact_phone_appointments = ''
+    assert location.phone == 'main'
+  end
+
   # rubocop:disable Metrics/AbcSize, Metrics/MethodLength
   def test_to_storepoint
     assert storepoint_attr.keys.map(&:to_s) == TestSites::StorePoint::HEADERS


### PR DESCRIPTION
Closes: #60

 ## Goal
Return a Storepoint phone number based on the following precedence: `location_contact_phone_covid`, `location_contact_phone_appointments`, `location_contact_phone_main`.
