### PR TITLE
Issue template 2 of 2

### DIFF
--- a/.github/ISSUE_TEMPLATE.md
+++ b/.github/ISSUE_TEMPLATE.md
@@ -1,0 +1,61 @@
+-----[FOR BUGS]-----
+
+Stakeholders: TBD
+
+## Description
+
+Provide as much background as you need to get the implementer up to speed on the
+problem to be solved. This can also include screenshots, excerpts from support
+emails, and links to other issues or pull requests.
+
+
+## Steps to Reproduce
+
+Don't forget to point out the difference between what *should* happen and what
+*does* happen. Here's an example:
+
+1. Login as a super admin
+2. Go to /admin/reports
+3. Click on the "Provider Billing Report" link
+4. A 500 error page is displayed instead of a confirmation page.
+
+
+## Questions
+
+* Is this bug reproducible by engineering?
+  * yes or no
+* What is the impact?
+  * which users are affected? does it happen all the time? how many bills does it affect?
+
+
+
+-----[FOR ADMIN SUPPORT]-----
+
+[Link to Fogbugz case <xxxx>](<url>)
+
+
+-----[FOR EVERYTHING ELSE]-----
+
+Stakeholders: TBD
+
+## Goal
+
+Explain the **goal** of this issue. Focus on the problem that
+needs to be solved, and not on a particular solution. For example: "Make it
+easier for users to reset their passwords"
+
+
+## Description
+
+Provide as much background as you need to get the implementer up to speed on the
+problem to be solved. This can also include screenshots, excerpts from support
+emails, and links to other issues or pull requests.
+
+
+## Success Criteria
+
+How would a stakeholder test whether the issue has been completed or not?
+
+You can put "TBD" here if we don't yet know enough about the problem to be
+solved. But we should make every effort to define success criteria *before*
+starting on a ticket.

--- a/.github/ISSUE_TEMPLATE.md
+++ b/.github/ISSUE_TEMPLATE.md
@@ -4,34 +4,30 @@ Stakeholders: TBD
 
 ## Description
 
-Provide as much background as you need to get the implementer up to speed on the
-problem to be solved. This can also include screenshots, excerpts from support
-emails, and links to other issues or pull requests.
-
+1. Give as much background as you need to help the implementer understand the
+problem.
+2. Include any useful info such as screenshots and/or links to other issues or
+pull requests.
 
 ## Steps to Reproduce
 
 Don't forget to point out the difference between what *should* happen and what
 *does* happen. Here's an example:
 
-1. Login as a super admin
-2. Go to /admin/reports
-3. Click on the "Provider Billing Report" link
+1. Login as an admin.
+2. Go to /reports.
+3. Click on the "Billing Report" link.
 4. A 500 error page is displayed instead of a confirmation page.
-
 
 ## Questions
 
 * Is this bug reproducible by engineering?
-  * yes or no
-* What is the impact?
-  * which users are affected? does it happen all the time? how many bills does it affect?
+  - [ ] yes
+  - [ ] no
 
-
-
------[FOR ADMIN SUPPORT]-----
-
-[Link to Fogbugz case <xxxx>](<url>)
+* What's the impact?
+  * Which users are affected?
+  * Does it happen all the time?
 
 
 -----[FOR EVERYTHING ELSE]-----
@@ -40,22 +36,20 @@ Stakeholders: TBD
 
 ## Goal
 
-Explain the **goal** of this issue. Focus on the problem that
-needs to be solved, and not on a particular solution. For example: "Make it
-easier for users to reset their passwords"
-
+Explain the **goal** of this issue, focusing on the problem to solve—not on a
+particular solution. For example: "Make it easier for users to reset their
+passwords".
 
 ## Description
 
-Provide as much background as you need to get the implementer up to speed on the
-problem to be solved. This can also include screenshots, excerpts from support
-emails, and links to other issues or pull requests.
-
+1. Give as much background as you need to help the implementer understand the
+problem.
+2. Include any useful info such as screenshots and/or links to other issues or
+pull requests.
 
 ## Success Criteria
 
-How would a stakeholder test whether the issue has been completed or not?
+How would a stakeholder test whether the issue has been resolved?
 
-You can put "TBD" here if we don't yet know enough about the problem to be
-solved. But we should make every effort to define success criteria *before*
-starting on a ticket.
+Enter "TBD" here if we don't yet have enough info, but we should make every
+effort to define success criteria *before* starting on a ticket.


### PR DESCRIPTION
 ## Goal
Add structure to opened issues.

 ## Approach
This is the second of two template options, based on one we used at a previous gig. The first option was GitHub's default, #65.