### PR TITLE
UX: all tasks log start/stop timestamps

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -13,7 +13,6 @@ task default: :test
 
 task :diff_sources do |task|
   timestamp do
-    load 'lib/test_sites.rb' unless defined?(TestSites)
     TestSites::SourceDiff.new.list
   end
 end
@@ -34,7 +33,6 @@ end
 
 task :geocode do |task|
   timestamp do
-    load 'lib/test_sites.rb' unless defined?(TestSites)
     TestSites::Geocoder.new.process(TestSites::Source.new)
   end
 end
@@ -42,7 +40,6 @@ end
 task :geocode_cac_locations do |task|
   timestamp do
     load 'lib/models.rb' unless defined?(TestSites)
-    load 'lib/test_sites.rb' unless defined?(TestSites)
     TestSites::Geocoder.new.process(CACLocation.all_from_api)
   end
 end
@@ -50,7 +47,6 @@ end
 desc 'Check that the hour listings in the source file all parse correctly'
 task :check_hours do |task|
   timestamp do
-    load 'lib/test_sites.rb' unless defined?(TestSites)
     TestSites::HourParser.new.check_all
   end
 end
@@ -58,7 +54,6 @@ end
 desc 'Check how many of the hour listings obtained from CAC parse correctly'
 task :check_cac_hours do |task|
   timestamp do
-    load 'lib/test_sites.rb' unless defined?(TestSites)
     TestSites::HourParser.new.check_all(
       hours_to_check: TestSites::CAC.all_hours
     )
@@ -68,7 +63,6 @@ end
 desc 'List duplicate addresses in source file'
 task :list_dups do |task|
   timestamp do
-    load 'lib/test_sites.rb' unless defined?(TestSites)
     dups = TestSites::Source.new.dup_addresses
     logger.info dups.join("\n") unless dups.blank?
   end
@@ -87,14 +81,12 @@ end
 
 task :dump_additions do |task|
   timestamp do
-    load 'lib/test_sites.rb' unless defined?(TestSites)
     TestSites::SourceDiff.new.dump_additions
   end
 end
 
 task :compare_cac do |task|
   timestamp do
-    load 'lib/test_sites.rb' unless defined?(TestSites)
     TestSites::CAC.new.dump_matches
   end
 end

--- a/Rakefile
+++ b/Rakefile
@@ -1,81 +1,102 @@
 # frozen_string_literal: true
 
+load 'lib/test_sites.rb' unless defined?(TestSites)
 require 'logger'
 
-def self.logger
-  @logger = Logger.new(STDOUT)
-  @logger.level = ENV['LOG_LEVEL'].blank? ? Logger::ERROR : ENV['LOG_LEVEL']
-  @logger
+def self.timestamp(&block)
+  TestSites.logger.info "Started at #{task.timestamp}..."
+  yield
+  TestSites.logger.info "Finished at #{task.timestamp}."
 end
 
 task default: :test
 
-task :diff_sources do
-  load 'lib/test_sites.rb' unless defined?(TestSites)
-  TestSites::SourceDiff.new.list
-end
-
-desc 'Export all CAC locations to Storepoint'
-task :export_cac_as_storepoint do
-  load 'lib/models.rb' unless defined?(CACLocation)
-  sp_locations = CACLocation.to_storepoint(CACLocation.all_from_api)
-
-  CSV.open(TestSites::DataFile.path('cac_as_storepoint.csv'), 'w',
-           write_headers: true,
-           headers: TestSites::StorePoint::HEADERS.join(',')) do |csv|
-    sp_locations.each { |location| csv << location.values }
+task :diff_sources do |task|
+  timestamp do
+    load 'lib/test_sites.rb' unless defined?(TestSites)
+    TestSites::SourceDiff.new.list
   end
 end
 
-task :geocode do
-  load 'lib/test_sites.rb' unless defined?(TestSites)
-  TestSites::Geocoder.new.process(TestSites::Source.new)
+desc 'Export all CAC locations to Storepoint'
+task :export_cac_as_storepoint do |task|
+  timestamp do
+    load 'lib/models.rb' unless defined?(CACLocation)
+    sp_locations = CACLocation.to_storepoint(CACLocation.all_from_api)
+
+    CSV.open(TestSites::DataFile.path('cac_as_storepoint.csv'), 'w',
+             write_headers: true,
+             headers: TestSites::StorePoint::HEADERS.join(',')) do |csv|
+      sp_locations.each { |location| csv << location.values }
+    end
+  end
 end
 
-task :geocode_cac_locations do
-  load 'lib/models.rb' unless defined?(TestSites)
-  load 'lib/test_sites.rb' unless defined?(TestSites)
-  TestSites::Geocoder.new.process(CACLocation.all_from_api)
+task :geocode do |task|
+  timestamp do
+    load 'lib/test_sites.rb' unless defined?(TestSites)
+    TestSites::Geocoder.new.process(TestSites::Source.new)
+  end
+end
+
+task :geocode_cac_locations do |task|
+  timestamp do
+    load 'lib/models.rb' unless defined?(TestSites)
+    load 'lib/test_sites.rb' unless defined?(TestSites)
+    TestSites::Geocoder.new.process(CACLocation.all_from_api)
+  end
 end
 
 desc 'Check that the hour listings in the source file all parse correctly'
-task :check_hours do
-  load 'lib/test_sites.rb' unless defined?(TestSites)
-  TestSites::HourParser.new.check_all
+task :check_hours do |task|
+  timestamp do
+    load 'lib/test_sites.rb' unless defined?(TestSites)
+    TestSites::HourParser.new.check_all
+  end
 end
 
 desc 'Check how many of the hour listings obtained from CAC parse correctly'
-task :check_cac_hours do
-  load 'lib/test_sites.rb' unless defined?(TestSites)
-  TestSites::HourParser.new.check_all(
-    hours_to_check: TestSites::CAC.all_hours
-  )
+task :check_cac_hours do |task|
+  timestamp do
+    load 'lib/test_sites.rb' unless defined?(TestSites)
+    TestSites::HourParser.new.check_all(
+      hours_to_check: TestSites::CAC.all_hours
+    )
+  end
 end
 
 desc 'List duplicate addresses in source file'
-task :list_dups do
-  load 'lib/test_sites.rb' unless defined?(TestSites)
-  dups = TestSites::Source.new.dup_addresses
-  logger.info dups.join("\n") unless dups.blank?
+task :list_dups do |task|
+  timestamp do
+    load 'lib/test_sites.rb' unless defined?(TestSites)
+    dups = TestSites::Source.new.dup_addresses
+    logger.info dups.join("\n") unless dups.blank?
+  end
 end
 
 desc 'Export source file as Storepoint CSV'
-task :update_storepoint do
-  Rake::Task['list_dups'].execute
-  Rake::Task['check_hours'].execute
-  Rake::Task['geocode'].execute
-  TestSites::StorePoint.new.update
-  logger.info "*** Updated #{TestSites::StorePoint::OUTPUT_FILE}"
+task :update_storepoint do |task|
+  timestamp do
+    Rake::Task['list_dups'].execute
+    Rake::Task['check_hours'].execute
+    Rake::Task['geocode'].execute
+    TestSites::StorePoint.new.update
+    logger.info "*** Updated #{TestSites::StorePoint::OUTPUT_FILE}"
+  end
 end
 
-task :dump_additions do
-  load 'lib/test_sites.rb' unless defined?(TestSites)
-  TestSites::SourceDiff.new.dump_additions
+task :dump_additions do |task|
+  timestamp do
+    load 'lib/test_sites.rb' unless defined?(TestSites)
+    TestSites::SourceDiff.new.dump_additions
+  end
 end
 
-task :compare_cac do
-  load 'lib/test_sites.rb' unless defined?(TestSites)
-  TestSites::CAC.new.dump_matches
+task :compare_cac do |task|
+  timestamp do
+    load 'lib/test_sites.rb' unless defined?(TestSites)
+    TestSites::CAC.new.dump_matches
+  end
 end
 
 require 'rake/testtask'

--- a/Rakefile
+++ b/Rakefile
@@ -3,7 +3,7 @@
 load 'lib/test_sites.rb' unless defined?(TestSites)
 require 'logger'
 
-def self.timestamp(&block)
+def self.timestamp
   TestSites.logger.info "Started at #{task.timestamp}..."
   yield
   TestSites.logger.info "Finished at #{task.timestamp}."
@@ -11,14 +11,14 @@ end
 
 task default: :test
 
-task :diff_sources do |task|
+task :diff_sources do
   timestamp do
     TestSites::SourceDiff.new.list
   end
 end
 
 desc 'Export all CAC locations to Storepoint'
-task :export_cac_as_storepoint do |task|
+task :export_cac_as_storepoint do
   timestamp do
     load 'lib/models.rb' unless defined?(CACLocation)
     sp_locations = CACLocation.to_storepoint(CACLocation.all_from_api)
@@ -31,13 +31,13 @@ task :export_cac_as_storepoint do |task|
   end
 end
 
-task :geocode do |task|
+task :geocode do
   timestamp do
     TestSites::Geocoder.new.process(TestSites::Source.new)
   end
 end
 
-task :geocode_cac_locations do |task|
+task :geocode_cac_locations do
   timestamp do
     load 'lib/models.rb' unless defined?(TestSites)
     TestSites::Geocoder.new.process(CACLocation.all_from_api)
@@ -45,14 +45,14 @@ task :geocode_cac_locations do |task|
 end
 
 desc 'Check that the hour listings in the source file all parse correctly'
-task :check_hours do |task|
+task :check_hours do
   timestamp do
     TestSites::HourParser.new.check_all
   end
 end
 
 desc 'Check how many of the hour listings obtained from CAC parse correctly'
-task :check_cac_hours do |task|
+task :check_cac_hours do
   timestamp do
     TestSites::HourParser.new.check_all(
       hours_to_check: TestSites::CAC.all_hours
@@ -61,7 +61,7 @@ task :check_cac_hours do |task|
 end
 
 desc 'List duplicate addresses in source file'
-task :list_dups do |task|
+task :list_dups do
   timestamp do
     dups = TestSites::Source.new.dup_addresses
     logger.info dups.join("\n") unless dups.blank?
@@ -69,7 +69,7 @@ task :list_dups do |task|
 end
 
 desc 'Export source file as Storepoint CSV'
-task :update_storepoint do |task|
+task :update_storepoint do
   timestamp do
     Rake::Task['list_dups'].execute
     Rake::Task['check_hours'].execute
@@ -79,13 +79,13 @@ task :update_storepoint do |task|
   end
 end
 
-task :dump_additions do |task|
+task :dump_additions do
   timestamp do
     TestSites::SourceDiff.new.dump_additions
   end
 end
 
-task :compare_cac do |task|
+task :compare_cac do
   timestamp do
     TestSites::CAC.new.dump_matches
   end

--- a/Rakefile
+++ b/Rakefile
@@ -1,7 +1,6 @@
 # frozen_string_literal: true
 
 load 'lib/test_sites.rb' unless defined?(TestSites)
-require 'logger'
 
 def self.timestamp
   TestSites.logger.info "Started at #{task.timestamp}..."
@@ -64,7 +63,7 @@ desc 'List duplicate addresses in source file'
 task :list_dups do
   timestamp do
     dups = TestSites::Source.new.dup_addresses
-    logger.info dups.join("\n") unless dups.blank?
+    TestSites.logger.info dups.join("\n") unless dups.blank?
   end
 end
 
@@ -75,7 +74,7 @@ task :update_storepoint do
     Rake::Task['check_hours'].execute
     Rake::Task['geocode'].execute
     TestSites::StorePoint.new.update
-    logger.info "*** Updated #{TestSites::StorePoint::OUTPUT_FILE}"
+    TestSites.logger.info "*** Updated #{TestSites::StorePoint::OUTPUT_FILE}"
   end
 end
 

--- a/lib/test_sites.rb
+++ b/lib/test_sites.rb
@@ -27,8 +27,7 @@ module TestSites
   VERSION ||= '0.1.0'
 
   def self.logger
-    @logger ||= Logger.new(STDOUT)
-    @logger.level = ENV['LOG_LEVEL'].blank? ? Logger::ERROR : ENV['LOG_LEVEL']
+    @logger ||= Logger.new(STDOUT, level: ENV['LOG_LEVEL'] || 'info')
     @logger
   end
 end


### PR DESCRIPTION
 ## Goal
Identify latency issues with long-running tasks by logging the time at the beginning and end of every rake task.

 ## Approach
1. Add `self.timestamp` to do the logging.
2. Log everything using `TestSites.logger`.
3. Change every task to call 1.
4. Default log-level to `info`.

 ## Deployment
To override log level:
```
export LOG_LEVEL=error
```
To restore default level on macOS:
```
unset LOG_LEVEL
```