### PR TITLE
Clean up rake output

### DIFF
--- a/lib/test_sites/geocoder_results.rb
+++ b/lib/test_sites/geocoder_results.rb
@@ -40,7 +40,7 @@ module TestSites
         Hashie::Mash.new(
           all_results.each_with_object({}) do |(address, geo_result_list), acc|
             if geo_result_list.empty?
-              TestSites.logger.error "skipping bad address: #{address}"
+              TestSites.logger.warn "skipping bad address: #{address}"
               next
             end
 

--- a/lib/test_sites/hour_parser.rb
+++ b/lib/test_sites/hour_parser.rb
@@ -281,10 +281,10 @@ module TestSites
         TestSites.logger.debug "Hour specifiers that couldn't be parsed:"
         TestSites.logger.debug hours_left.map { |spec| "* #{spec}" }.join("\n")
       end
-      puts "*** didnt' parse: "
-      puts hours_left.join("\n")
-      TestSites.logger.debug
-      "Hour specifiers: parsed #{found.size} out of #{unique_hours.size}"
+      TestSites.logger.debug "didn't parse:"
+      TestSites.logger.debug hours_left.join("\n")
+      TestSites.logger.debug "Hour specifiers: parsed #{found.size} out of "\
+                             "#{unique_hours.size}"
     end
     # rubocop:enable Metrics/AbcSize, Metrics/MethodLength
 

--- a/lib/test_sites/hour_parser.rb
+++ b/lib/test_sites/hour_parser.rb
@@ -283,7 +283,7 @@ module TestSites
       end
       TestSites.logger.debug "didn't parse:"
       TestSites.logger.debug hours_left.join("\n")
-      TestSites.logger.debug "Hour specifiers: parsed #{found.size} out of "\
+      TestSites.logger.info "Hour specifiers: parsed #{found.size} out of "\
                              "#{unique_hours.size}"
     end
     # rubocop:enable Metrics/AbcSize, Metrics/MethodLength


### PR DESCRIPTION
 ## Goal
Clean-up log output based on sensible [guidelines](https://stackoverflow.com/a/2031209).

 ## Approach
1. Replace `puts` with logger calls.
2. Use `warn` for skipping messages.
3. Use `debug` for unprocessable data.
4. Use `info` for tallies.
