### PR TITLE
Add hours parsing to CACLocation

### DIFF
--- a/test/models/cac_location_test.rb
+++ b/test/models/cac_location_test.rb
@@ -10,7 +10,14 @@ class CACLocationTest < TestSitesTestCase
     'created_on': 'Fri, 03 Apr 2020 00:17:24 GMT',
     'data_source': 'crowdsource',
     'deleted_on': nil,
-    'external_location_id': nil,
+    'external_location_id':
+      '[{"use": "primary", "kind": "esriFieldTypeOID", "alias": "OBJECTID", ' \
+       '"field": "OBJECTID", "value": "4086", "system": "Esri", ' \
+       '"assigner": "GISCorps"}' \
+       ', null, {"use": "other", "kind": "esriFieldTypeGlobalID", "alias": ' \
+        '"GlobalID", "field": "GlobalID", "value": ' \
+        '"81e0292d-65fc-4fed-9cc8-5878719598e3", "system": "Esri", ' \
+        '"assigner": "Esri"}]',
     'geojson': nil,
     'is_collecting_samples': true,
     'is_collecting_samples_by_appointment_only': true,
@@ -53,63 +60,6 @@ class CACLocationTest < TestSitesTestCase
     'updated_on': 'Fri, 03 Apr 2020 00:17:24 GMT'
   }.freeze
 
-  ATTRIBUTES_GISCORP = {
-    'additional_information_for_patients':
-  'https://www.capecodhealth.org/medical-services/infectious-disease/coronavirus/covid-19-testing-process/',
-    'created_on': 'Sat, 11 Apr 2020 17:49:16 GMT',
-    'data_source':
-  '[GISCorps] https://www.capecodhealth.org/medical-services/infectious-disease/coronavirus/covid-19-testing-process/',
-    'deleted_on': nil,
-    'external_location_id':
-  '[{"use": "primary", "kind": "esriFieldTypeOID", "alias": "OBJECTID", ' \
-   '"field": "OBJECTID", "value": "4086", "system": "Esri", ' \
-   '"assigner": "GISCorps"}' \
-   ', null, {"use": "other", "kind": "esriFieldTypeGlobalID", "alias": ' \
-    '"GlobalID", "field": "GlobalID", "value": ' \
-    '"81e0292d-65fc-4fed-9cc8-5878719598e3", "system": "Esri", ' \
-    '"assigner": "Esri"}]',
-    'geojson': {},
-    'is_collecting_samples': false,
-    'is_collecting_samples_by_appointment_only': false,
-    'is_collecting_samples_for_others': true,
-    'is_collecting_samples_onsite': false,
-    'is_evaluating_symptoms': false,
-    'is_evaluating_symptoms_by_appointment_only': false,
-    'is_hidden': false,
-    'is_ordering_tests': false,
-    'is_ordering_tests_only_for_those_who_meeting_criteria': true,
-    'is_processing_samples': false,
-    'is_processing_samples_for_others': false,
-    'is_processing_samples_onsite': false,
-    'is_verified': true,
-    'location_address_locality': '',
-    'location_address_postal_code': '',
-    'location_address_region': nil,
-    'location_address_street': '273 Teaticket Highway, Falmouth, MA 2540',
-    'location_contact_phone_appointments': '',
-    'location_contact_phone_covid': '',
-    'location_contact_phone_main': '508-862-5595',
-    'location_contact_url_covid_appointments': '',
-    'location_contact_url_covid_info': '',
-    'location_contact_url_covid_screening_tool': '',
-    'location_contact_url_covid_virtual_visit': '',
-    'location_contact_url_main':
-  'https://www.barnstablecountyhealth.org/covid-19/latest-updates-and-info',
-    'location_hours_of_operation': '',
-    'location_id': 'c1750bd9-755e-0cb4-2beb-0807487e1460',
-    'location_latitude': 41.5676230929044,
-    'location_longitude': -70.5946701920671,
-    'location_name': 'Cape Cod Healthcare Urgent Care - Falmouth',
-    'location_place_of_service_type': 'Private',
-    'location_specific_testing_criteria':
-      'The day-to-day operations at this location are ...',
-    'location_status': 'Operational',
-    'raw_data': '{}',
-    'record_id': 3235,
-    'reference_publisher_of_criteria': '',
-    'updated_on': 'Fri, 24 Apr 2020 12:50:49 GMT'
-  }.freeze
-
   def test_phone
     location = CACLocation
                .new(location_contact_phone_covid: 'covid',
@@ -138,7 +88,14 @@ class CACLocationTest < TestSitesTestCase
     assert storepoint_attr[:tags] == 'Hospital'
     assert_in_delta storepoint_attr[:lat], 40.7421225
     assert_in_delta storepoint_attr[:lng], -73.9739642
-    assert storepoint_attr[:hours] == '9am - 5pm'
+
+    assert location.storepoint_mon == '9AM-5PM'
+    assert location.storepoint_tue == '9AM-5PM'
+    assert location.storepoint_wed == '9AM-5PM'
+    assert location.storepoint_thu == '9AM-5PM'
+    assert location.storepoint_fri == '9AM-5PM'
+    assert location.storepoint_sat == '9AM-5PM'
+    assert location.storepoint_sun == '9AM-5PM'
 
     CACLocation::CAC_TO_STOREPOINT_MAPPING.each do |key, _value|
       next unless key.nil?
@@ -149,18 +106,20 @@ class CACLocationTest < TestSitesTestCase
   # rubocop:enable Metrics/AbcSize, Metrics/MethodLength
 
   def test_arcgis_global_id
-    assert storepoint_giscorps.arcgis_global_id ==
-           '81e0292d-65fc-4fed-9cc8-5878719598e3'
+    assert location.arcgis_global_id == '81e0292d-65fc-4fed-9cc8-5878719598e3'
   end
 
   private
 
-  def storepoint_attr
-    @storepoint_attr ||= CACLocation.new(ATTRIBUTES).to_storepoint
+  def location
+    return @location if @location
+    @location = CACLocation.new(ATTRIBUTES)
+    CACLocation.add_hours_by_day(@location, TestSites::HourParser.new)
+    @location
   end
 
-  def storepoint_giscorps
-    @storepoint_giscorps ||= CACLocation.new(ATTRIBUTES_GISCORP)
+  def storepoint_attr
+    @storepoint_attr ||= location.to_storepoint
   end
 end
 # rubocop:enable Metrics/ClassLength

--- a/test/models/cac_location_test.rb
+++ b/test/models/cac_location_test.rb
@@ -113,6 +113,7 @@ class CACLocationTest < TestSitesTestCase
 
   def location
     return @location if @location
+
     @location = CACLocation.new(ATTRIBUTES)
     CACLocation.add_hours_by_day(@location, TestSites::HourParser.new)
     @location

--- a/test/unit/hour_parser_test.rb
+++ b/test/unit/hour_parser_test.rb
@@ -12,22 +12,15 @@ class HourParserTest < TestSitesTestCase
     assert_equal hours, Array.new(7, '8AM-9PM')
   end
 
-  # rubocop:disable Metrics/MethodLength
   def test_24_hour_single_day_specifier
-    hours = @hour_parser.parse(
-      '8:00 am - 4:30 pm Monday, Tuesday, Wednesday, ' \
-      'Thursday, Friday; 24 hours Sunday'
-    ).to_array
-    assert_equal hours,
-                 [
-                   '8:00AM-4:30PM',
-                   '8:00AM-4:30PM',
-                   '8:00AM-4:30PM',
-                   '8:00AM-4:30PM',
-                   '8:00AM-4:30PM',
-                   '',
-                   '24 hours'
-                 ]
+    hours = @hour_parser.parse('8:00 am - 4:30 pm Monday, Tuesday, Wednesday, '\
+      'Thursday, Friday; 24 hours Sunday').to_array
+    assert_equal hours, ['8:00AM-4:30PM',
+                         '8:00AM-4:30PM',
+                         '8:00AM-4:30PM',
+                         '8:00AM-4:30PM',
+                         '8:00AM-4:30PM',
+                         '',
+                         '24 hours']
   end
-  # rubocop:enable Metrics/MethodLength
 end


### PR DESCRIPTION
Closes: #31

 ## Goal
Parse out hours for `CACLocations` so Storepoint can use them.

 ## Approach
1. Add `CACLocation.add_hours_by_day`, which `CACLocation.all_from_api ` calls, to leverage the existing parsing logic.
2. Wrap the resulting `hours_array` with `#storepoint_mon`, `#storepoint_tue`, `#storepoint_wed`... getters.
